### PR TITLE
Increased support to python 3.9

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,10 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8]
+        python-version: [3.9]
         include:
           - os: ubuntu-latest
             python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +28,8 @@ jobs:
     - name: Install conda dependencies
       shell: bash -l {0}
       run: |
-        conda install rtree pip pytest geopandas
+        conda install rtree pip pytest
+        pip install geopandas
         pip install --upgrade --force-reinstall shapely
         pip install pytest-cov
         pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ Option 1: Install from PIP or Conda (recommended for analysts):
 1. Create a new environment:
     ``conda create --name revx python=3.7``
 
+        - NOTE: reVX currently only supports python versions 3.7, 3.8, and 3.9. Python 3.10+ conflicts with the reV dependency.
+
 2. Activate directory:
     ``conda activate revx``
 
@@ -83,7 +85,7 @@ Option 1: Install from PIP or Conda (recommended for analysts):
     2) ``conda install nrel-revx --channel=nrel``
 
         - NOTE: The best guarantee you will have of a correct installation is by following the same `installation process that we use for our automated test suite <https://github.com/NREL/reVX/blob/7932a095c222e2e5c70bfc7b4813a68a1da2493a/.github/workflows/pull_request_tests.yml#L29-L33>`_.
-        
+
         - NOTE: If you install using conda and you want to use:
             * `HSDS <https://github.com/NREL/hsds-examples>`_ you will also need to install h5pyd manually: ``pip install h5pyd``
             * `Turbine Flicker <https://nrel.github.io/reVX/_cli/reVX.turbine_flicker.turbine_flicker.html>`_ you will need to install `HOPP <https://github.com/nrel/HOPP>`_ manually: ``pip install HOPP``

--- a/reVX/version.py
+++ b/reVX/version.py
@@ -3,4 +3,4 @@
 reVX version number
 """
 
-__version__ = "0.3.45"
+__version__ = "0.3.46"

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     license="BSD 3-Clause",
     zip_safe=False,
     keywords="reVX",
-    python_requires='>=3.7,<3.9',
+    python_requires='>=3.7,<3.10',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
@@ -97,6 +97,7 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     test_suite="tests",
     install_requires=install_requires,


### PR DESCRIPTION
Allow python 3.9 installations now. Python 3.10+ conflict with reV, but only because reV is on an outdated version of PySAM. Once the reV PySAM dependency is updated, we should revisit the reVX < python 3.10 requirement. 

The upgrade to Python 3.9 was requested by a reVX end-user who is trying to meet cyber security requirements.