### PR TITLE
Pp/Exclusions Memory Management

### DIFF
--- a/reVX/turbine_flicker/turbine_flicker.py
+++ b/reVX/turbine_flicker/turbine_flicker.py
@@ -737,7 +737,7 @@ def compute_flicker_exclusions(hub_height, rotor_diameter, points, res_fpath,
 
             for i, future in enumerate(as_completed(futures)):
                 flicker_shifts = future.result()
-                point = futures[future]
+                point = futures.pop(future)
                 row_idx, col_idx = _get_building_indices(building_layer,
                                                          point.name,
                                                          resolution=resolution)

--- a/reVX/utilities/exclusions.py
+++ b/reVX/utilities/exclusions.py
@@ -757,20 +757,20 @@ class ExclusionsConverter:
                     logger.error(error)
                     raise ExclusionsCheckError(error)
 
-                # lat, lon = tif.lat_lon
-                # if not np.allclose(h5.latitude, lat, atol=coord_atol):
-                #     error = ('Latitude coordinates {} and {} do not match to '
-                #              'within {} degrees!'
-                #              .format(geotiff, excl_h5, coord_atol))
-                #     logger.error(error)
-                #     raise ExclusionsCheckError(error)
+                lat, lon = tif.lat_lon
+                if not np.allclose(h5.latitude, lat, atol=coord_atol):
+                    error = ('Latitude coordinates {} and {} do not match to '
+                             'within {} degrees!'
+                             .format(geotiff, excl_h5, coord_atol))
+                    logger.error(error)
+                    raise ExclusionsCheckError(error)
 
-                # if not np.allclose(h5.longitude, lon, atol=coord_atol):
-                #     error = ('Longitude coordinates {} and {} do not match to '
-                #              'within {} degrees!'
-                #              .format(geotiff, excl_h5, coord_atol))
-                #     logger.error(error)
-                #     raise ExclusionsCheckError(error)
+                if not np.allclose(h5.longitude, lon, atol=coord_atol):
+                    error = ('Longitude coordinates {} and {} do not match to '
+                             'within {} degrees!'
+                             .format(geotiff, excl_h5, coord_atol))
+                    logger.error(error)
+                    raise ExclusionsCheckError(error)
 
     @classmethod
     def _parse_tiff(cls, geotiff, excl_h5=None, chunks=(128, 128),


### PR DESCRIPTION
So apparently futures spawned by [the local exclusions runner](https://github.com/NREL/reVX/blob/3a3694a171ab672b35865a27ba2f64c470280dcc/reVX/utilities/exclusions.py#L342) can compute the local exclusion they are assigned with pretty quickly. So quickly, in fact, that [the `for` loop that merges the local exclusions](https://github.com/NREL/reVX/blob/3a3694a171ab672b35865a27ba2f64c470280dcc/reVX/utilities/exclusions.py#L351) could not keep up in some cases. If this happened, the future would just store its result and the setbacks runner would spawn a new future to calculate the exclusions for the next set of local regulations. 

Well it turns out that when the result of each future is a ~1.5GB array, and your futures run so fast that you get a backlog of 100-200 local regulation arrays to merge, you're gunna run out of memory pretty fast. 

New approach is to spawn futures in batches of "max_workers". That way, the merge loop has time to merge all output arrays and release the memory before the next batch of results comes pouring in.

Memory management is super fun :)