### PR TITLE
Exclusions mask command

### DIFF
--- a/tests/test_mean_wind_dirs.py
+++ b/tests/test_mean_wind_dirs.py
@@ -28,7 +28,7 @@ EXCL_DICT = {'ri_srtm_slope': {'inclusion_range': (None, 5),
                                   'exclude_nodata': True}}
 
 RTOL = 0.001
-ATOL = 0
+ATOL = 0.1
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_setbacks.py
+++ b/tests/test_setbacks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access
+# pylint: disable=protected-access,unused-argument,redefined-outer-name
 """
 Setbacks tests
 """

--- a/tests/test_setbacks.py
+++ b/tests/test_setbacks.py
@@ -1368,6 +1368,11 @@ def test_cli_merge_setbacks(runner):
         with Geotiff(out_fp) as tif:
             assert np.allclose(tif.values, 0)
 
+        os.chdir(td)
+        runner.invoke(main, ['merge', '-td', td, '-o', "m.tif"])
+        with Geotiff(os.path.join(td, "m.tif")) as tif:
+            assert np.allclose(tif.values, 1)
+
 
 def execute_pytest(capture='all', flags='-rapP'):
     """Execute module as pytest with detailed summary report.

--- a/tests/test_setbacks.py
+++ b/tests/test_setbacks.py
@@ -85,6 +85,24 @@ def county_wind_regulations_gpkg():
                                   regulations_fpath=REGS_GPKG)
 
 
+@pytest.fixture()
+def return_to_main_test_dir():
+    """Return to the starting dir after running a test.
+
+    This fixture helps avoid issues for downstream pytests if the test
+    code contains any calls to os.chdir().
+    """
+    # Startup
+    previous_dir = os.getcwd()
+
+    try:
+        # test happens here
+        yield
+    finally:
+        # teardown (i.e. return to original dir)
+        os.chdir(previous_dir)
+
+
 def test_setback_regulations_init():
     """Test initializing a normal regulations file. """
     regs = SetbackRegulations(10, regulations_fpath=REGS_FPATH, multiplier=1.1)
@@ -1338,7 +1356,7 @@ def test_cli_saving(runner):
     LOGGERS.clear()
 
 
-def test_cli_merge_setbacks(runner):
+def test_cli_merge_setbacks(runner, return_to_main_test_dir):
     """Test the setbacks merge CLI command."""
 
     with ExclusionLayers(EXCL_H5) as excl:


### PR DESCRIPTION
Added a simple CLI `mask` command to aggregate multiple exclusion layers into a single layer based on an exclusion dictionary and save the result to a geotiff. 

Also made the setbacks `merge` slightly more flexible.