### PR TITLE
Reinforcement costs now computed and reported per-MW

### DIFF
--- a/reVX/least_cost_xmission/least_cost_paths.py
+++ b/reVX/least_cost_xmission/least_cost_paths.py
@@ -646,27 +646,22 @@ def _rasterize_transmission(transmission_lines, xmission_config, cost_shape,
     """Rasterize transmission lines and assemble them into a dict. """
 
     transmission_lines_dict = {}
-    capacities = sorted(xmission_config['power_classes'],
-                        key=lambda x: xmission_config['power_classes'][x])
+    capacities = sorted(xmission_config['power_classes'].values())
     v_min = 0
     for capacity in capacities[:-1]:
-        power_class = str(xmission_config['power_classes'][capacity])
-        cost_layer = 'tie_line_costs_{}MW'.format(power_class)
-        v_max = xmission_config['power_to_voltage'][power_class]
-
+        v_max = xmission_config['power_to_voltage'][str(capacity)]
         curr_lines = transmission_lines[
             (transmission_lines["voltage"] > v_min)
             & (transmission_lines["voltage"] <= v_max)
         ]
         out = _rasterize_transmission_layer(curr_lines, cost_shape,
                                             cost_transform)
-        transmission_lines_dict[cost_layer] = out
+        transmission_lines_dict[int(capacity)] = out
         v_min = v_max
 
     curr_lines = transmission_lines[transmission_lines["voltage"] > v_min]
-    cost_layer = 'tie_line_costs_{}'.format(capacities[-1])
     out = _rasterize_transmission_layer(curr_lines, cost_shape, cost_transform)
-    transmission_lines_dict[cost_layer] = out
+    transmission_lines_dict[int(capacities[-1])] = out
     return transmission_lines_dict
 
 

--- a/reVX/least_cost_xmission/least_cost_xmission_cli.py
+++ b/reVX/least_cost_xmission/least_cost_xmission_cli.py
@@ -349,7 +349,7 @@ def merge_reinforcement_costs(ctx, cost_fpath, reinforcement_cost_fpath,
 
     logger.info("Merging reinforcement costs into transmission costs...")
 
-    r_cols = ["reinforcement_dist_km", "reinforcement_cost"]
+    r_cols = ["reinforcement_dist_km", "reinforcement_cost_per_mw"]
     costs[r_cols] = r_costs.loc[costs["trans_gid"], r_cols].values
 
     logger.info("Writing output to {!r}".format(out_file))

--- a/tests/test_xmission_least_cost_paths.py
+++ b/tests/test_xmission_least_cost_paths.py
@@ -227,9 +227,9 @@ def test_reinforcement_cli(runner, ba_regions_and_network_nodes):
         assert len(test["reinforcement_poi_lon"].unique()) == 4
 
         assert len(test) == 69
-        assert np.isclose(test.reinforcement_cost.min(), 1235514.316,
+        assert np.isclose(test.reinforcement_cost_per_mw.min(), 3332.695,
                           atol=0.001)
-        assert np.isclose(test.reinforcement_cost.max(), 156662169.251,
+        assert np.isclose(test.reinforcement_cost_per_mw.max(), 569757.740,
                           atol=0.001)
         assert np.isclose(test.reinforcement_dist_km.min(), 1.918, atol=0.001)
         assert np.isclose(test.reinforcement_dist_km.max(), 80.353, atol=0.001)


### PR DESCRIPTION
After taking a much closer look at the first round of reinforcement cost results, Trieu et al. decided that smaller wind/solar farms should not have to pay the same reinforcement costs as larger wind/solar farms. Instead, they wanted the cost to be a fraction proportional to the farm size, so the reinforcement costs are now computed and reported as $/MW instead of a flat dollar amount, which can then scale with the built-out plant size.