### PR TITLE
Geotiff faster `lat_lon`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ NREL-rex>=0.2.80
 psycopg2-binary>=2.8
 pyproj>=3.0.1
 pywavelets>=1.0
-rasterio>=1.0
+rasterio>=1.2.10
 scikit-image>=0.18
 scikit-learn>=0.22
 shapely<2.0.0

--- a/tests/test_geotiff.py
+++ b/tests/test_geotiff.py
@@ -105,8 +105,8 @@ def test_geotiff_profile():
     geotiff = os.path.join(DIR, 'ri_padus.tif')
     __, profile = extract_layer(EXCL_H5, 'ri_padus')
     with Geotiff(geotiff) as f:
-        assert (rasterio.CRS.from_string(f.profile["crs"])
-                == rasterio.CRS.from_string(profile["crs"]))
+        assert (rasterio.crs.CRS.from_string(f.profile["crs"])
+                == rasterio.crs.CRS.from_string(profile["crs"]))
         assert np.allclose(f.profile["transform"], profile["transform"])
         assert f.profile["tiled"] == profile["tiled"]
         assert f.profile["nodata"] == profile["nodata"]
@@ -137,6 +137,21 @@ def test_geotiff_lat_lon():
         assert lon.max() < -70.856
         assert lat.min() > 40.8558
         assert lat.max() < 42.0189
+
+
+@pytest.mark.parametrize("inds", [([1, 5, 10], [3, 4, 5]),
+                                  (slice(1, 20), slice(None))])
+def test_geotiff_lat_lon_sliced(inds):
+    """Test Geotiff Lat/Lon sliced accessor"""
+    geotiff = os.path.join(DIR, 'ri_padus.tif')
+    x_inds, y_inds = inds
+    with Geotiff(geotiff) as f:
+        lat_truth, lon_truth = f.lat_lon
+        lat = f["latitude", x_inds, y_inds]
+        lon = f["longitude", x_inds, y_inds]
+
+        assert np.allclose(lon, lon_truth[x_inds, y_inds])
+        assert np.allclose(lat, lat_truth[x_inds, y_inds])
 
 
 def execute_pytest(capture='all', flags='-rapP'):


### PR DESCRIPTION
I got tired of waiting 93 minutes for a `lat_lon` calculation that takes < 45 seconds with vectorized code so I added that here. 
Still takes a while for large Geotiffs but it's much more manageable.

Also updated `rasterio` req, since newer version was causing some tests to fail. Haven't run full suite, so I will fix any remaining tests that fail due to the new dependecy