### PR TITLE
Add logging guard

### DIFF
--- a/reVX/__init__.py
+++ b/reVX/__init__.py
@@ -5,7 +5,7 @@ Renewable Energy Potential(V) EXchange Tool (reVX)
 from __future__ import print_function, division, absolute_import
 import logging
 if not logging.getLogger().handlers:
-    logging.getLogger().addHandler(logging.NullHandler)
+    logging.getLogger().addHandler(logging.NullHandler())
 import os
 
 import reVX.plexos as reV_plexos

--- a/reVX/__init__.py
+++ b/reVX/__init__.py
@@ -3,6 +3,9 @@
 Renewable Energy Potential(V) EXchange Tool (reVX)
 """
 from __future__ import print_function, division, absolute_import
+import logging
+if not logging.getLogger().handlers:
+    logging.getLogger().addHandler(logging.NullHandler)
 import os
 
 import reVX.plexos as reV_plexos


### PR DESCRIPTION
Add guard to protect from silly third-party packages forcing a `logging.basicConfig` call.