### PR TITLE
Changing sc_gid to sc_point_gid for matching gid points

### DIFF
--- a/reVX/plexos/base.py
+++ b/reVX/plexos/base.py
@@ -200,7 +200,7 @@ class PlexosNode:
             Total Supply Curve Point Capacity
         """
 
-        sc_gid = int(sc_point['sc_gid'])
+        sc_gid = int(sc_point['sc_point_gid'])
         buildout = float(sc_point['built_capacity'])
         capacity = float(sc_point['potential_capacity'])
 
@@ -724,7 +724,7 @@ class BaseProfileAggregation(ABC):
             taken based on the bespoke indexing.
         """
 
-        df['res_gids'] = [[g] for g in df['sc_gid']]
+        df['res_gids'] = [[g] for g in df['sc_point_gid']]
 
         if 'gid_counts' in df:
             if isinstance(df['gid_counts'].values[0], str):

--- a/reVX/plexos/base.py
+++ b/reVX/plexos/base.py
@@ -39,7 +39,7 @@ class PlexosNode:
     node. Resource within each supply curve point is built in order of cf_mean.
     """
 
-    def __init__(self, sc_build, cf_fpath, res_gids=None,
+    def __init__(self, sc_build, cf_fpath, gid_column="sc_gid", res_gids=None,
                  force_full_build=False, forecast_fpath=None,
                  forecast_map=None, dset_tag=None):
         """
@@ -54,6 +54,9 @@ class PlexosNode:
         cf_fpath : str
             File path to capacity factor file (reV gen output) to
             get profiles from.
+        gid_column: str, optional
+            Reference column to use for supply curve gid. Valid options are sc_gid 
+            and sc_point_gid.
         res_gids : list | np.ndarray, optional
             Resource GID's available in cf_fpath, if None pull from cf_fpath,
             by default None
@@ -82,6 +85,7 @@ class PlexosNode:
         if res_gids is None:
             res_gids = self._get_res_gids(cf_fpath)
 
+        self._gid_column = gid_column
         self._res_gids = res_gids
         self._forecast_fpath = forecast_fpath
         self._forecast_map = forecast_map
@@ -136,7 +140,7 @@ class PlexosNode:
 
         sc_point = self._sc_build.loc[row_idx]
         sc_gid, res_gids, gen_gids, gid_counts, gid_capacity, buildout, _ = \
-            self._parse_sc_point(sc_point, self._res_gids)
+            self._parse_sc_point(sc_point, self._res_gids, self._gid_column)
 
         sc_meta = pd.DataFrame({'gen_gid': gen_gids,
                                 'res_gid': res_gids,
@@ -164,7 +168,7 @@ class PlexosNode:
         return sc_gid, sc_meta, buildout
 
     @staticmethod
-    def _parse_sc_point(sc_point, all_res_gids):
+    def _parse_sc_point(sc_point, all_res_gids, gid_column):
         """Parse data from sc point.
 
         Parameters
@@ -177,6 +181,8 @@ class PlexosNode:
             column in the cf_fpath meta data.
         all_res_gids : list | np.ndarray
             ALL resource GID's available in cf_fpath
+        gid_column : str
+            String to use for sc_gid.
 
         Returns
         -------
@@ -200,7 +206,7 @@ class PlexosNode:
             Total Supply Curve Point Capacity
         """
 
-        sc_gid = int(sc_point['sc_point_gid'])
+        sc_gid = int(sc_point[gid_column])
         buildout = float(sc_point['built_capacity'])
         capacity = float(sc_point['potential_capacity'])
 
@@ -706,7 +712,7 @@ class BaseProfileAggregation(ABC):
         return names
 
     @staticmethod
-    def convert_bespoke_sc(df):
+    def convert_bespoke_sc(df, gid_column):
         """Convert a bespoke supply curve table to reference resource gids
         (res_gids) based on the bespoke generation outputs that are on the
         supply curve grid not the resource grid
@@ -715,6 +721,8 @@ class BaseProfileAggregation(ABC):
         ----------
         table : pd.DataFrame
             rev_sc and reeds_build inner joined on supply curve gid.
+        gid_column : str
+            String to use for sc_gid.
 
         Returns
         -------
@@ -724,7 +732,7 @@ class BaseProfileAggregation(ABC):
             taken based on the bespoke indexing.
         """
 
-        df['res_gids'] = [[g] for g in df['sc_point_gid']]
+        df['res_gids'] = [[g] for g in df[gid_column]]
 
         if 'gid_counts' in df:
             if isinstance(df['gid_counts'].values[0], str):

--- a/reVX/plexos/rev_reeds_plexos.py
+++ b/reVX/plexos/rev_reeds_plexos.py
@@ -311,7 +311,7 @@ class PlexosAggregation(BaseProfileAggregation):
         reeds_build : pd.DataFrame
             Same as input but without lat/lon columns if matched.
         """
-        join_on = 'sc_gid'
+        join_on = 'sc_point_gid'
         reeds_build = reeds_build.sort_values(join_on)
         reeds_sc_gids = reeds_build[join_on].values
         rev_mask = rev_sc[join_on].isin(reeds_sc_gids)
@@ -391,8 +391,8 @@ class PlexosAggregation(BaseProfileAggregation):
 
         reeds_build = reeds_build[year_mask]
 
-        join_on = 'sc_gid'
-        if 'sc_gid' not in rev_sc or 'sc_gid' not in reeds_build:
+        join_on = 'sc_point_gid'
+        if 'sc_point_gid' not in rev_sc or 'sc_point_gid' not in reeds_build:
             raise KeyError('GID must be in reV SC and REEDS Buildout tables!')
 
         rev_sc, reeds_build = cls._check_rev_reeds_coordinates(rev_sc,
@@ -444,9 +444,9 @@ class PlexosAggregation(BaseProfileAggregation):
             else:
                 gid_col = list(gid_col)
 
-            for i, sc_gids in enumerate(gid_col):
-                if any(m in sc_gids for m in missing):
-                    bad_sc_points.append(self.sc_build.iloc[i]['sc_gid'])
+            for i, sc_point_gid in enumerate(gid_col):
+                if any(m in sc_point_gid for m in missing):
+                    bad_sc_points.append(self.sc_build.iloc[i]['sc_point_gid'])
 
             wmsg = ('There are {} SC points with missing gids: {}'
                     .format(len(bad_sc_points), bad_sc_points))
@@ -465,7 +465,7 @@ class PlexosAggregation(BaseProfileAggregation):
             (in reeds but not in reV resource).
         """
         if any(bad_sc_points):
-            bad_bool = self.sc_build['sc_gid'].isin(bad_sc_points)
+            bad_bool = self.sc_build['sc_point_gid'].isin(bad_sc_points)
             bad_cap_arr = self.sc_build.loc[bad_bool, 'built_capacity'].values
             good_bool = ~bad_bool
             bad_cap = bad_cap_arr.sum()

--- a/reVX/plexos/rev_reeds_plexos.py
+++ b/reVX/plexos/rev_reeds_plexos.py
@@ -42,7 +42,7 @@ class PlexosAggregation(BaseProfileAggregation):
                  forecast_fpath=None, build_year=2050, plexos_columns=None,
                  force_full_build=False, force_shape_map=False,
                  plant_name_col=None, tech_tag=None, res_class=None,
-                 timezone='UTC', dset_tag=None, bespoke=False,
+                 timezone='UTC', dset_tag=None, bespoke=False, gid_column='sc_gid',
                  max_workers=None):
         """
         Parameters
@@ -114,6 +114,9 @@ class PlexosAggregation(BaseProfileAggregation):
             profiles at the supply curve grid resolution which is different
             than traditional reV generation outputs that are on the resource
             grid resolution.
+        gid_column: str, optional
+            Reference column to use for supply curve gid. Valid options are sc_gid 
+            and sc_point_gid.
         max_workers : int | None
             Max workers for parallel profile aggregation. None uses all
             available workers. 1 will run in serial.
@@ -135,6 +138,7 @@ class PlexosAggregation(BaseProfileAggregation):
         self._res_class = res_class
         self._dset_tag = dset_tag if dset_tag is not None else ""
         self._bespoke = bespoke
+        self._gid_column = gid_column
 
         if plexos_columns is None:
             plexos_columns = tuple()
@@ -284,7 +288,7 @@ class PlexosAggregation(BaseProfileAggregation):
         return plexos_nodes
 
     @staticmethod
-    def _check_rev_reeds_coordinates(rev_sc, reeds_build, atol=0.5):
+    def _check_rev_reeds_coordinates(rev_sc, reeds_build, atol=0.5, gid_column='sc_gid'):
         """Check that the coordinates are the same in rev and reeds buildouts.
 
         Parameters
@@ -301,6 +305,9 @@ class PlexosAggregation(BaseProfileAggregation):
             also include "plexos_node_gid" which will explicitly assign a
             supply curve point buildout to a single plexos node. If included,
             all points must be assigned to plexos nodes.
+        gid_column: str, optional
+            Reference column to use for supply curve gid. Valid options are sc_gid 
+            and sc_point_gid.
         atol : float
             Maximum difference in coord matching.
 
@@ -311,7 +318,7 @@ class PlexosAggregation(BaseProfileAggregation):
         reeds_build : pd.DataFrame
             Same as input but without lat/lon columns if matched.
         """
-        join_on = 'sc_point_gid'
+        join_on = gid_column
         reeds_build = reeds_build.sort_values(join_on)
         reeds_sc_gids = reeds_build[join_on].values
         rev_mask = rev_sc[join_on].isin(reeds_sc_gids)
@@ -342,7 +349,7 @@ class PlexosAggregation(BaseProfileAggregation):
 
     @classmethod
     def _parse_rev_reeds(cls, rev_sc, reeds_build, build_year=2050,
-                         bespoke=False):
+                         bespoke=False, gid_column="sc_gid"):
         """Parse and combine reV SC and REEDS buildout tables into single table
 
         Parameters
@@ -391,8 +398,8 @@ class PlexosAggregation(BaseProfileAggregation):
 
         reeds_build = reeds_build[year_mask]
 
-        join_on = 'sc_point_gid'
-        if 'sc_point_gid' not in rev_sc or 'sc_point_gid' not in reeds_build:
+        join_on = gid_column
+        if gid_column not in rev_sc or gid_column not in reeds_build:
             raise KeyError('GID must be in reV SC and REEDS Buildout tables!')
 
         rev_sc, reeds_build = cls._check_rev_reeds_coordinates(rev_sc,
@@ -446,7 +453,7 @@ class PlexosAggregation(BaseProfileAggregation):
 
             for i, sc_point_gid in enumerate(gid_col):
                 if any(m in sc_point_gid for m in missing):
-                    bad_sc_points.append(self.sc_build.iloc[i]['sc_point_gid'])
+                    bad_sc_points.append(self.sc_build.iloc[i][self._gid_column])
 
             wmsg = ('There are {} SC points with missing gids: {}'
                     .format(len(bad_sc_points), bad_sc_points))
@@ -465,7 +472,7 @@ class PlexosAggregation(BaseProfileAggregation):
             (in reeds but not in reV resource).
         """
         if any(bad_sc_points):
-            bad_bool = self.sc_build['sc_point_gid'].isin(bad_sc_points)
+            bad_bool = self.sc_build[self._gid_column].isin(bad_sc_points)
             bad_cap_arr = self.sc_build.loc[bad_bool, 'built_capacity'].values
             good_bool = ~bad_bool
             bad_cap = bad_cap_arr.sum()

--- a/reVX/plexos/utilities.py
+++ b/reVX/plexos/utilities.py
@@ -99,6 +99,9 @@ class DataCleaner:
 
     REV_NAME_MAP = {'gid': 'sc_gid',
                     'sq_km': 'area_sq_km',
+                    'capacity_mw_ac': 'potential_capacity',
+                    'capacity_mw': 'potential_capacity',
+                    'capacity_ac': 'potential_capacity', 
                     'capacity': 'potential_capacity',
                     'resource_ids': 'res_gids',
                     'resource_ids_cnts': 'gid_counts'}


### PR DESCRIPTION
## Purpose of this PR

- Changing `sc_gid` to `sc_pointg_gid` for the nodal Plexos aggregation,
- Adding updated column names from the supply curve files and profiles datasets.

##  Background

We experienced some difficulties when matching `sc_gid` for the latest NTP runs that use the latest reV runs. After a discussion with @mmowers and @WilliamsTravis, we found out that we should be using `sc_point_gid` instead of `sc_gid` to match across supply curves and profiles datasets that are used for the nodal translation.

I added this PR on this branch since we end-up using the updated bespoke wind profiles as well. Is there a timeline for your branch to be merged into main, @grantbuster ?

