### PR TITLE
Rename column when reading SC Point GIDs from file

### DIFF
--- a/reVX/cli.py
+++ b/reVX/cli.py
@@ -234,9 +234,10 @@ def layers_from_h5(ctx, out_dir, layers, hsds):
               help=('Path to JSON file containing the ``"excl_dict"`` '
                     'key which points to the exclusion dictionary defining '
                     'the mask that should be generated. A typical reV '
-                    'aggregation config satisfied this requirement. If this'
-                    'file also contains an ``"excl_fpath"` key, the value'
-                    'from the file will override the CLI argument input.'))
+                    'aggregation config satisfied this requirement. If this '
+                    'file also contains an ``"excl_fpath"`` key, the value '
+                    'from the file will override the ``--excl_h5`` CLI '
+                    'argument input.'))
 @click.option('--out', '-o', required=True, type=STR,
               help=('Output name. If this string value ends in ".tif" '
                     'or ".tiff", this input is assumed to be a path to an '

--- a/reVX/config/least_cost_xmission.py
+++ b/reVX/config/least_cost_xmission.py
@@ -521,7 +521,7 @@ class LeastCostXmissionConfig(AnalysisConfig):
             elif (isinstance(sc_point_gids, str)
                   and sc_point_gids.endswith(".csv")):
                 points = pd.read_csv(sc_point_gids)
-                sc_point_gids = list(points.sc_point_gids.values)
+                sc_point_gids = list(points.sc_point_gid.values)
 
             if not isinstance(sc_point_gids, list):
                 raise ValueError('sc_point_gids must be a list or path to a '

--- a/reVX/least_cost_xmission/least_cost_xmission_cli.py
+++ b/reVX/least_cost_xmission/least_cost_xmission_cli.py
@@ -135,8 +135,11 @@ def from_config(ctx, config, verbose):
 @click.option('--sc_point_gids', '-gids', type=INTLIST, show_default=True,
               default=None, help=("List of sc_point_gids to connect to. If "
                                   "running `from_config`, this can also be a "
-                                  "path to a CSV file with a 'sc_point_gids' "
-                                  "column containing the GID's to run."))
+                                  "path to a CSV file with a 'sc_point_gid' "
+                                  "column containing the GID's to run. Note "
+                                  "the missing 's' in the column name - this "
+                                  "makes it seamless to run on a supply curve "
+                                  "output from reV"))
 @click.option('--nn_sinks', '-nn', type=int,
               show_default=True, default=2,
               help=("Number of nearest neighbor sinks to use for clipping "

--- a/reVX/rpm/rpm_cli.py
+++ b/reVX/rpm/rpm_cli.py
@@ -185,7 +185,8 @@ def cluster(ctx, rpm_meta, region_col, dist_rank_filter, contiguous_filter):
                                        job_tag=name, rpm_region_col=region_col,
                                        max_workers=max_workers,
                                        dist_rank_filter=dist_rank_filter,
-                                       contiguous_filter=contiguous_filter)
+                                       contiguous_filter=contiguous_filter,
+                                       method_kwargs={"n_init": 10})
 
     logger.info('reVX - RPM clustering methods complete.')
     ctx.obj['RPM_CLUSTERS'] = rpm_clusters

--- a/reVX/utilities/reeds_cols.py
+++ b/reVX/utilities/reeds_cols.py
@@ -107,11 +107,11 @@ def add_extra_data(data_frame, extra_data, merge_col="sc_point_gid"):
     extra_data : list of dicts
         A list of dictionaries, where each dictionary contains two keys.
         The first key is "source", and its value must either be a
-        dictionary of field/ value pairs or a path to the extra data
+        dictionary of `field: value` pairs or a path to the extra data
         being extracted. The latter must be a path pointing to an
         HDF5 or JSON file (i.e. it must end in ".h5" or ".json"). The
         second key is "dsets", and it points to a list of dataset names
-        to extract from `data_fp`. For JSON and dictionary data
+        to extract from `source`. For JSON and dictionary data
         extraction, the values of the datasets must either be scalars or
         must match the length of the input `data_frame`. For HDF5 data,
         the datasets must be 1D datasets, and they will be merged with
@@ -188,11 +188,11 @@ def add_reeds_columns(supply_curve_fpath, out_fp=None, capacity_col="capacity",
     extra_data : list of dicts, optional
         A list of dictionaries, where each dictionary contains two keys.
         The first key is "source", and its value must either be a
-        dictionary of field/ value pairs or a path to the extra data
+        dictionary of `field: value` pairs or a path to the extra data
         being extracted. The latter must be a path pointing to an
         HDF5 or JSON file (i.e. it must end in ".h5" or ".json"). The
         second key is "dsets", and it points to a list of dataset names
-        to extract from `data_fp`. For JSON and dictionary data
+        to extract from `source`. For JSON and dictionary data
         extraction, the values of the datasets must either be scalars or
         must match the length of the input `data_frame`. For HDF5 data,
         the datasets must be 1D datasets, and they will be merged with

--- a/reVX/version.py
+++ b/reVX/version.py
@@ -3,4 +3,4 @@
 reVX version number
 """
 
-__version__ = "0.3.53"
+__version__ = "0.3.54"

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -142,7 +142,8 @@ def test_rpm(max_workers, pre_extract_inclusions):
             output_kwargs=None,
             dist_rank_filter=True,
             contiguous_filter=False,
-            pre_extract_inclusions=pre_extract_inclusions)
+            pre_extract_inclusions=pre_extract_inclusions,
+            method_kwargs={"n_init": 10})
 
         TEST_CLUSTERS = os.path.join(td, 'rpm_cluster_outputs_{}.csv'
                                          .format(JOB_TAG))
@@ -163,7 +164,8 @@ def test_rpm_no_exclusions():
             max_workers=1,
             output_kwargs=None,
             dist_rank_filter=True,
-            contiguous_filter=False)
+            contiguous_filter=False,
+            method_kwargs={"n_init": 10})
 
         TEST_CLUSTERS = os.path.join(td, 'rpm_cluster_outputs_{}.csv'
                                          .format(JOB_TAG))


### PR DESCRIPTION
QOL change: This allows users to input reV supply curves into the transmission config and have the code run seamlessly.

Also includes:
    - Minor updates to command line documentation
    - Fix for RMP tests with scikit-learn v1.4.0
