### PR TITLE
`Geotiff` handler updates

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -9,8 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10']
+        python-version: [3.11]
         include:
+          - os: ubuntu-latest
+            python-version: '3.10'
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest

--- a/reVX/handlers/geotiff.py
+++ b/reVX/handlers/geotiff.py
@@ -71,6 +71,8 @@ class Geotiff:
         if isinstance(ds, str):
             if ds == 'meta':
                 out = self._get_meta(*ds_slice)
+            elif ds.casefold() == 'lat_lon':
+                out = self._get_lat_lon(*ds_slice)
             elif ds.lower().startswith('lat'):
                 out = self._get_lat_lon(*ds_slice)[0]
             elif ds.lower().startswith('lon'):

--- a/reVX/handlers/geotiff.py
+++ b/reVX/handlers/geotiff.py
@@ -341,15 +341,18 @@ class Geotiff:
         lon : ndarray
             Projected longitude coordinates
         """
-        y_slice, x_slice = self._unpack_slices(*ds_slice)
+        row_slice, col_slice = self._unpack_slices(*ds_slice)
 
-        cols, rows = np.meshgrid(np.arange(self.n_cols),
-                                 np.arange(self.n_rows))
+        if any(isinstance(s, slice) for s in [row_slice, col_slice]):
+            cols, rows = np.meshgrid(np.arange(self.n_cols)[col_slice],
+                                     np.arange(self.n_rows)[row_slice])
+        else:
+            cols = np.arange(self.n_cols)[col_slice]
+            rows = np.arange(self.n_rows)[row_slice]
 
         pixel_center_translation = Affine.translation(0.5, 0.5)
         adjusted_transform = self._src.transform * pixel_center_translation
-        lon, lat = adjusted_transform * [cols[y_slice, x_slice],
-                                         rows[y_slice, x_slice]]
+        lon, lat = adjusted_transform * [cols, rows]
 
         transformer = Transformer.from_crs(self._src.profile["crs"],
                                            'epsg:4326', always_xy=True)

--- a/reVX/version.py
+++ b/reVX/version.py
@@ -3,4 +3,4 @@
 reVX version number
 """
 
-__version__ = "0.3.58"
+__version__ = "0.3.59"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 addfips>=0.4.0
 dask>=2.8
 dask[array]>=2.8
-fiona>=1.9.0
+fiona~=1.9.0
 geopandas>=0.8
 NREL-gaps>=0.3.3
 NREL-reV>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     test_suite="tests",
     install_requires=install_requires,

--- a/tests/test_geotiff.py
+++ b/tests/test_geotiff.py
@@ -118,11 +118,12 @@ def test_geotiff_profile():
         assert f.profile["width"] == profile["width"]
 
 
-def test_geotiff_lat_lon():
+@pytest.mark.parametrize("use_prop", [True, False])
+def test_geotiff_lat_lon(use_prop):
     """Test Geotiff Lat/Lon"""
-    geotiff = os.path.join(DIR, 'ri_padus.tif')
+    geotiff = os.path.join(DIR, "ri_padus.tif")
     with Geotiff(geotiff) as f:
-        lat, lon = f.lat_lon
+        lat, lon = f.lat_lon if use_prop else f["lAt_LON"]
         cols, rows = np.meshgrid(np.arange(f.n_cols), np.arange(f.n_rows))
         transform = rasterio.transform.Affine(*f.profile["transform"])
         xs, ys = rasterio.transform.xy(transform, rows, cols)


### PR DESCRIPTION
Specifically, added a few changes to make lat/lon calculation more flexible when it comes to memory usage. 

Full reV exclusion la/lon calculation will still take ~13GB of memory, but users can now have more control if they want to do the computation piecewise.