### PR TITLE
Add pass-through option for layer builder

### DIFF
--- a/reVX/config/transmission_layer_creation.py
+++ b/reVX/config/transmission_layer_creation.py
@@ -83,6 +83,9 @@ class LayerBuildConfig(BaseModel, extra='forbid'):
     This input can be one or more ranges of raster values to apply to
     barrier/friction. The value of overlapping ranges are added together."""
 
+    pass_through: Optional[bool] = False
+    """Pass cost data through without estra processing."""
+
     rasterize: Optional[Rasterize] = None
     """Rasterize a vector and save as layer"""
 

--- a/reVX/least_cost_xmission/layers/layer_creator.py
+++ b/reVX/least_cost_xmission/layers/layer_creator.py
@@ -173,6 +173,15 @@ class LayerCreator(BaseLayerCreator):
 
             return processed
 
+        if config.pass_through:
+            if config.extent == ALL:
+                return data
+
+            mask = self._get_mask(config.extent)
+            processed = np.zeros(self._io_handler.shape, dtype=self._dtype)
+            processed[mask] = data[mask]
+            return processed
+
         # No bins specified, has to be map. Assign cells values based on map.
         temp = np.zeros(self._io_handler.shape, dtype=self._dtype)
         for key, val in config.map.items():  # type: ignore[union-attr]

--- a/reVX/least_cost_xmission/layers/layer_creator.py
+++ b/reVX/least_cost_xmission/layers/layer_creator.py
@@ -335,16 +335,17 @@ class LayerCreator(BaseLayerCreator):
 
         mutex_entries = [config.map, config.bins, config.global_value]
         num_entries = sum(entry is not None for entry in mutex_entries)
+        num_entries += int(config.pass_through)
         if num_entries > 1:
-            raise ValueError('Keys "global_value", "map", and "bins" are '
-                             'mutually exclusive but more than one was '
-                             'found in raster config '
+            raise ValueError('Keys "global_value", "map", "bins", and '
+                             '"pass_through" are mutually exclusive but '
+                             'more than one was found in raster config '
                              f'{config}')
 
         if num_entries < 1:
-            raise ValueError('Either "global_value", "map", or "bins" must '
-                             'be specified fora raster, but none were found '
-                             'in config '
+            raise ValueError('Either "global_value", "map", "bins", and '
+                             '"pass_through" must be specified fora raster, '
+                             'but none were found in config '
                              f'{config}')
 
 

--- a/reVX/version.py
+++ b/reVX/version.py
@@ -3,4 +3,4 @@
 reVX version number
 """
 
-__version__ = "0.3.60"
+__version__ = "0.3.61"

--- a/tests/test_xmission_layer_friction_barrier_builder.py
+++ b/tests/test_xmission_layer_friction_barrier_builder.py
@@ -145,6 +145,28 @@ def test_map():
                                 [0, 9, 0]])).all()
 
 
+def test_pass_through():
+    """Test pass through key in LayerBuildConfig """
+    data = np.array([[1, 1, 1],
+                     [2, 2, 2],
+                     [3, 3, 3]])
+    config = LayerBuildConfig(extent='wet', pass_through=True)
+    result = builder._process_raster_layer(data, config)
+    assert (result == np.array([[1, 0, 0],
+                                [2, 0, 0],
+                                [3, 0, 0]])).all()
+
+    config = LayerBuildConfig(extent='landfall', pass_through=True)
+    result = builder._process_raster_layer(data, config)
+    assert (result == np.array([[0, 1, 0],
+                                [0, 2, 0],
+                                [0, 3, 0]])).all()
+
+    config = LayerBuildConfig(extent='all', pass_through=True)
+    result = builder._process_raster_layer(data, config)
+    assert (result == data).all()
+
+
 def test_bin_config_sanity_checking():
     """
     Test cost binning config sanity checking.


### PR DESCRIPTION
Add an option to pass data straight through to the H5 file, so that users can add their own custom layers to the build process