### PR TITLE
Deprecate some inputs

### DIFF
--- a/reVX/config/least_cost_xmission.py
+++ b/reVX/config/least_cost_xmission.py
@@ -23,8 +23,7 @@ class LeastCostXmissionConfig(AnalysisConfig):
     """Config framework for Least Cost Xmission"""
 
     NAME = 'LeastCostXmission'
-    REQUIREMENTS = ('cost_fpath', 'features_fpath', 'capacity_class',
-                    'cost_layers')
+    REQUIREMENTS = ('cost_fpath', 'features_fpath', 'cost_layers')
 
     def __init__(self, config):
         """
@@ -127,25 +126,11 @@ class LeastCostXmissionConfig(AnalysisConfig):
         return rid_col
 
     @property
-    def capacity_class(self):
-        """
-        Capacity class, either {capacity}MW or capacity value in MW
-        """
-        return self['capacity_class']
-
-    @property
     def resolution(self):
         """
         SC point resolution
         """
         return self.get('resolution', RESOLUTION)
-
-    @property
-    def xmission_config(self):
-        """
-        Xmission config input
-        """
-        return self.get('xmission_config', None)
 
     @property
     def length_mult_kind(self):

--- a/reVX/config/least_cost_xmission.py
+++ b/reVX/config/least_cost_xmission.py
@@ -11,8 +11,7 @@ from reVX.least_cost_xmission.config.constants import (CELL_SIZE,
                                                        RESOLUTION,
                                                        NUM_NN_SINKS,
                                                        CLIP_RASTER_BUFFER,
-                                                       MINIMUM_SPUR_DIST_KM,
-                                                       ISO_H5_LAYER_NAME)
+                                                       MINIMUM_SPUR_DIST_KM)
 from reV.supply_curve.extent import SupplyCurveExtent
 from reV.config.base_analysis_config import AnalysisConfig
 from reV.utilities.exceptions import ConfigError
@@ -195,13 +194,6 @@ class LeastCostXmissionConfig(AnalysisConfig):
         Final cost layer multiplier, defaults to ``1``.
         """
         return float(self.get('cost_multiplier_scalar', 1))
-
-    @property
-    def iso_regions_layer_name(self):
-        """
-        Name of ISO regions layer in `cost_fpath` file.
-        """
-        return self.get('iso_regions_layer_name', ISO_H5_LAYER_NAME)
 
     @property
     def cost_layers(self) -> List[dict]:

--- a/reVX/least_cost_xmission/README.md
+++ b/reVX/least_cost_xmission/README.md
@@ -278,15 +278,10 @@ The below file can be used to start a full CONUS analysis for the 1000MW power c
   "friction_layers": [
     {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 100}
   ],
-  "iso_regions_layer_name": "iso_regions",
   "log_directory": "/scratch/USER_NAME/log",
   "log_level": "INFO"
 }
 ```
-
-Note that the `iso_regions_layer_name` input is needed because our layer name
-is not the expected default value of `"ISO_regions"` (our layer name is
-lowercase).
 
 Assuming the above config file is saved as `config_conus.json` in the current directory, it can be kicked off with:
 
@@ -389,7 +384,6 @@ You should now have a file containing all of the reinforcement costs for the sub
     "friction_layers": [
       {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 100}
     ],
-    "iso_regions_layer_name": "iso_regions",
     "log_directory": "./logs",
     "log_level": "INFO",
     "min_line_length": 0,
@@ -444,7 +438,6 @@ Since we want to allow tie-line connections, we must first run LCP to determine 
     "friction_layers": [
       {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 5000}
     ],
-    "iso_regions_layer_name": "iso_regions",
     "log_directory": "./logs",
     "log_level": "INFO",
     "resolution": 128,

--- a/reVX/least_cost_xmission/README.md
+++ b/reVX/least_cost_xmission/README.md
@@ -254,7 +254,6 @@ Find least cost paths, costs, and connection costs on eagle login node for 1000M
 $ least-cost-xmission local \
     --cost_fpath /shared-projects/rev/exclusions/xmission_costs.h5 \
     --features_fpath /projects/rev/data/transmission/shapefiles/conus_allconns.gpkg \
-    --capacity_class 1000
     --cl tie_line_costs_1500MW
 ```
 
@@ -273,8 +272,7 @@ The below file can be used to start a full CONUS analysis for the 1000MW power c
   },
   "cost_fpath": "/shared-projects/rev/exclusions/xmission_costs.h5",
   "features_fpath": "/projects/rev/data/transmission/shapefiles/conus_allconns.gpkg",
-  "capacity_class": "1000",
-  "cost_layers": [{"layer_name": "tie_line_costs_{}MW"}],
+  "cost_layers": [{"layer_name": "tie_line_costs_1500MW"}],
   "friction_layers": [
     {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 100}
   ],
@@ -379,8 +377,7 @@ You should now have a file containing all of the reinforcement costs for the sub
     "features_fpath": "./substations_with_ba.gpkg",
     "regions_fpath": "./regions.gpkg",
     "region_identifier_column": "rr_id",
-    "capacity_class": "1000",
-    "cost_layers": [{"layer_name": "tie_line_costs_{}MW"}],
+    "cost_layers": [{"layer_name": "tie_line_costs_1500MW"}],
     "friction_layers": [
       {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 100}
     ],
@@ -429,9 +426,8 @@ Since we want to allow tie-line connections, we must first run LCP to determine 
     "features_fpath": "/path/to/substations_and_tlines.gpkg",
     "regions_fpath": "/path/to/regions.gpkg",
     "region_identifier_column": "rr_id",
-    "capacity_class": "200",  // 138 kV
     "cost_layers": [
-        {"layer_name": "tie_line_costs_{}MW"},
+        {"layer_name": "tie_line_costs_205MW"},
         {"layer_name": "swca_cultural_resources_risk"},
         {"layer_name": "swca_natural_resources_risk"}
     ],
@@ -543,7 +539,6 @@ Find least cost paths, costs, and connection costs on eagle login node for 100MW
 $ least-cost-xmission local \
     --cost_fpath /shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_costs.h5 \
     --features_fpath /shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_pois.gpkg \
-    --capacity_class 100
 ```
 Run the above analysis for only two SC points, using only one core.
 
@@ -551,7 +546,6 @@ Run the above analysis for only two SC points, using only one core.
 $ least-cost-xmission local -v \
     --cost_fpath /shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_costs.h5 \
     --features_fpath /shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_pois.gpkg \
-    --capacity_class 100 \
     --max_workers 1 \
     --sc_point_gids [36092,36093]
 ```
@@ -576,9 +570,8 @@ The value for `allocation` should be set to the desired SLURM allocation. The `m
   "name": "test",
   "cost_fpath": "/shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_costs.h5",
   "features_fpath": "/shared-projects/rev/transmission_tables/least_cost/offshore/aoswt_pois.gpkg",
-  "capacity_class": "100",
   "cost_layers": [
-    {"layer_name": "tie_line_costs_{}MW"},
+    {"layer_name": "tie_line_costs_102MW"},
   ],
   "friction_layers": [
     {"layer_name": "lcp_agg_costs", "multiplier_layer": "transmission_barrier", "multiplier_scalar": 100}
@@ -614,9 +607,8 @@ A sample config for WOWTS would look very similar:
   "log_level": "INFO",
   "cost_fpath": "/projects/rev/data/transmission/north_america/conus/least_cost/offshore/processing/conus_20240221.h5",
   "features_fpath": "/projects/rev/projects/wowts/data/20240223_poi_trans_feats.gpkg",
-  "capacity_class": "1000",
   "cost_layers": [
-    {"layer_name": "tie_line_costs_{}MW"},
+    {"layer_name": "tie_line_costs_1500MW"},
     {"layer_name": "wet_costs"},
     {"layer_name": "landfall_costs", "is_invariant": true},
   ],

--- a/reVX/least_cost_xmission/least_cost_xmission_cli.py
+++ b/reVX/least_cost_xmission/least_cost_xmission_cli.py
@@ -34,8 +34,7 @@ from reVX.least_cost_xmission.config.constants import (CELL_SIZE,
                                                        SUBSTATION_CAT,
                                                        MINIMUM_SPUR_DIST_KM,
                                                        CLIP_RASTER_BUFFER,
-                                                       NUM_NN_SINKS,
-                                                       ISO_H5_LAYER_NAME)
+                                                       NUM_NN_SINKS)
 from reVX.least_cost_xmission.least_cost_paths import min_reinforcement_costs
 from reVX.least_cost_xmission.trans_cap_costs import CostLayer
 
@@ -164,10 +163,6 @@ def from_config(ctx, config, verbose):
                    'cost layer')
 @click.option('--cost_multiplier_scalar', '-cmult', type=float,
               show_default=True, default=1, help="Final cost layer multiplier")
-@click.option('--iso_regions_layer_name', '-irln', default=ISO_H5_LAYER_NAME,
-              type=STR, show_default=True,
-              help='Name of ISO regions layer in `cost_fpath` file. The '
-                   "layer maps pixels to ISO region ID's (1, 2, 3, 4, etc.) .")
 @click.option('--max_workers', '-mw', type=INT,
               show_default=True, default=None,
               help=("Number of workers to use for processing, if 1 run in "
@@ -232,10 +227,9 @@ def local(ctx, cost_fpath, features_fpath, regions_fpath,
           region_identifier_column, capacity_class, resolution,
           xmission_config, min_line_length, sc_point_gids, nn_sinks,
           clipping_buffer, cost_multiplier_layer, cost_multiplier_scalar,
-          iso_regions_layer_name, max_workers, out_dir, log_dir, verbose,
-          save_paths, radius, expand_radius, mp_delay, simplify_geo,
-          cost_layers, friction_layers, tracked_layers,
-          length_mult_kind, cell_size, use_hard_barrier):
+          max_workers, out_dir, log_dir, verbose, save_paths, radius,
+          expand_radius, mp_delay, simplify_geo, cost_layers, friction_layers,
+          tracked_layers, length_mult_kind, cell_size, use_hard_barrier):
     """
     Run Least Cost Xmission on local hardware
     """
@@ -272,7 +266,6 @@ def local(ctx, cost_fpath, features_fpath, regions_fpath,
               "clipping_buffer": clipping_buffer,
               "cost_multiplier_layer": cost_multiplier_layer,
               "cost_multiplier_scalar": cost_multiplier_scalar,
-              "iso_regions_layer_name": iso_regions_layer_name,
               "max_workers": max_workers,
               "save_paths": save_paths,
               "simplify_geo": simplify_geo,
@@ -544,7 +537,6 @@ def get_node_cmd(config, gids):
             '-buffer {}'.format(SLURM.s(config.clipping_buffer)),
             '-cml {}'.format(SLURM.s(config.cost_multiplier_layer)),
             '-cmult {}'.format(SLURM.s(config.cost_multiplier_scalar)),
-            '-irln {}'.format(SLURM.s(config.iso_regions_layer_name)),
             '-mw {}'.format(SLURM.s(config.execution_control.max_workers)),
             '-o {}'.format(SLURM.s(config.dirout)),
             '-log {}'.format(SLURM.s(config.log_directory)),
@@ -606,7 +598,6 @@ def run_local(ctx, config):
                clipping_buffer=config.clipping_buffer,
                cost_multiplier_layer=config.cost_multiplier_layer,
                cost_multiplier_scalar=config.cost_multiplier_scalar,
-               iso_regions_layer_name=config.iso_regions_layer_name,
                region_identifier_column=config.region_identifier_column,
                max_workers=config.execution_control.max_workers,
                out_dir=config.dirout,

--- a/reVX/least_cost_xmission/trans_cap_costs.py
+++ b/reVX/least_cost_xmission/trans_cap_costs.py
@@ -1235,6 +1235,8 @@ class TransCapCosts(TieLineCosts):
 
         for int_col in ["end_row", "end_col", "poi_gid"]:
             features[int_col] = features[int_col].astype("Int64")
+        for float_col in  ["raw_line_cost", "dist_km"]:
+            features[float_col] = features[float_col].astype("float")
         return features
 
     def compute_connection_costs(self, features=None,

--- a/reVX/least_cost_xmission/trans_cap_costs.py
+++ b/reVX/least_cost_xmission/trans_cap_costs.py
@@ -24,15 +24,12 @@ from reVX.least_cost_xmission.config import parse_config
 from reVX.least_cost_xmission.config.constants import (TRANS_LINE_CAT,
                                                        SINK_CAT,
                                                        SINK_CONNECTION_COST,
-                                                       SUBSTATION_CAT,
-                                                       LOAD_CENTER_CAT,
                                                        CELL_SIZE,
                                                        SHORT_MULT,
                                                        MEDIUM_MULT,
                                                        SHORT_CUTOFF,
                                                        MEDIUM_CUTOFF,
-                                                       MINIMUM_SPUR_DIST_KM,
-                                                       ISO_H5_LAYER_NAME)
+                                                       MINIMUM_SPUR_DIST_KM)
 from reVX.utilities.exceptions import (InvalidMCPStartValueError,
                                        LeastCostPathNotFoundError)
 
@@ -825,13 +822,10 @@ class TransCapCosts(TieLineCosts):
     (least-cost tie-line cost + connection cost) for all features to be
     connected a single supply curve point
     """
-    _CHECK_FOR_INVALID_REGION = True
 
     def __init__(self, cost_fpath, sc_point, features, capacity_class,
                  cost_layer, start_indices, row_slice, col_slice,
-                 xmission_config=None,
-                 iso_regions_layer_name=ISO_H5_LAYER_NAME,
-                 cell_size=CELL_SIZE):
+                 xmission_config=None, cell_size=CELL_SIZE):
         """
         Parameters
         ----------
@@ -864,10 +858,6 @@ class TransCapCosts(TieLineCosts):
             multipliers. By default, ``None``.
         cost_multiplier_scalar : int | float, optional
             Final cost layer multiplier. By default, ``1``.
-        iso_regions_layer_name : str, default=:obj:`ISO_H5_LAYER_NAME`
-            Name of ISO regions layer in `cost_fpath` file. The layer
-            maps pixels to ISO region ID's (1, 2, 3, 4, etc.) .
-            By default, :obj:`ISO_H5_LAYER_NAME`.
         friction_layers : List[dict] | None, optional
             List of layers in H5 to be added to the cost raster to
             influence routing but NOT reported in final cost. Should
@@ -895,8 +885,6 @@ class TransCapCosts(TieLineCosts):
             square. By default, :obj:`CELL_SIZE`.
         """
         self._sc_point = sc_point
-        self._region_layer = None
-        self._iso_regions_layer_name = iso_regions_layer_name
         super().__init__(cost_fpath, start_indices, cost_layer, row_slice,
                          col_slice, cell_size=cell_size)
 
@@ -904,12 +892,6 @@ class TransCapCosts(TieLineCosts):
         self._capacity_class = self._config._parse_cap_class(capacity_class)
         self._features = self._prep_features(features)
         self._clip_mask = None
-
-    def _extract_data_from_cost_h5(self, fh):
-        """Extract extra info from cost H5 file. """
-        super()._extract_data_from_cost_h5(fh)
-        self._region_layer = fh[self._iso_regions_layer_name,
-                                self._row_slice, self._col_slice]
 
     @property
     def sc_point(self):
@@ -1049,123 +1031,6 @@ class TransCapCosts(TieLineCosts):
 
         return start_indices, row_slice, col_slice
 
-    def _calc_xformer_cost(self, features):
-        """
-        Compute transformer costs in $/MW for needed features, all
-        others will be 0
-
-        Parameters
-        ----------
-        features : pd.DataFrame
-            Table of transmission features to compute transformer costs
-            for
-        tie_line_voltage : int
-            Tie-line voltage in kV
-        config : str | dict | XmissionConfig
-            Transmission configuration
-
-        Returns
-        -------
-        xformer_costs : ndarray
-            vector of $/MW transformer costs
-        """
-
-        mask = features['category'] == SUBSTATION_CAT
-        mask &= features['max_volts'] < self.tie_line_voltage
-        if np.any(mask):
-            msg = ('Voltages for substations {} do not exceed tie-line '
-                   'voltage of {}'
-                   .format(features.loc[mask, 'trans_gid'].values,
-                           self.tie_line_voltage))
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        xformer_costs = np.zeros(len(features))
-        for volts, df in features.groupby('min_volts'):
-            idx = df.index.values
-            xformer_costs[idx] = self._config.xformer_cost(
-                volts, self.tie_line_voltage)
-
-        mask = features['category'] == TRANS_LINE_CAT
-        mask &= features['max_volts'] < self.tie_line_voltage
-        xformer_costs[mask] = 0
-
-        mask = features['min_volts'] <= self.tie_line_voltage
-        xformer_costs[mask] = 0
-
-        mask = features['region'] == self._config['iso_lookup']['TEPPC']
-        xformer_costs[mask] = 0
-
-        return xformer_costs
-
-    def _calc_sub_upgrade_cost(self, features):
-        """
-        Compute substation upgrade costs for needed features, all others
-        will be 0
-
-        Parameters
-        ----------
-        features : pd.DataFrame
-            Table of transmission features to compute transformer costs
-            for
-
-        Returns
-        -------
-        sub_upgrade_costs : ndarray
-            Substation upgrade costs in $
-        """
-
-        sub_upgrade_cost = np.zeros(len(features))
-        if self._CHECK_FOR_INVALID_REGION and np.any(features['region'] == 0):
-            mask = features['region'] == 0
-            msg = ('Features {} have an invalid region! Region must != 0!'
-                   .format(features.loc[mask, 'trans_gid'].values))
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        mask = features['category'].isin([SUBSTATION_CAT, LOAD_CENTER_CAT])
-        if np.any(mask):
-            for region, df in features.loc[mask].groupby('region'):
-                idx = df.index.values
-                sub_upgrade_cost[idx] = self._config.sub_upgrade_cost(
-                    region, self.tie_line_voltage)
-
-        return sub_upgrade_cost
-
-    def _calc_new_sub_cost(self, features):
-        """
-        Compute new substation costs for needed features, all others
-        will be 0
-
-        Parameters
-        ----------
-        features : pd.DataFrame
-            Table of transmission features to compute transformer costs
-            for
-
-        Returns
-        -------
-        new_sub_cost : ndarray
-            new substation costs in $
-        """
-
-        new_sub_cost = np.zeros(len(features))
-        if self._CHECK_FOR_INVALID_REGION and np.any(features['region'] == 0):
-            mask = features['region'] == 0
-            msg = ('Features {} have an invalid region! Region must != 0!'
-                   .format(features.loc[mask, 'trans_gid'].values))
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        mask = features['category'] == TRANS_LINE_CAT
-        if np.any(mask):
-            for region, df in features.loc[mask].groupby('region'):
-                idx = df.index.values
-                new_sub_cost[idx] = self._config.new_sub_cost(
-                    region, self.tie_line_voltage)
-
-        return new_sub_cost
-
     def _prep_features(self, features):
         """
         Shift feature row and col indices of transmission features from
@@ -1302,17 +1167,15 @@ class TransCapCosts(TieLineCosts):
             logger.debug('Feat index is: %s', feat_idx)
 
             row, col = feat_idx
-            region = self._region_layer[row, col]
             row += self.row_offset
             col += self.col_offset
             poi_gid = self._full_shape[1] * row + col
-            logger.debug('Adding row, col, poi_gid, region: %d, %d, %d, %s',
-                         row, col, poi_gid, str(region))
+            logger.debug('Adding row, col, poi_gid: %d, %d, %d',
+                         row, col, poi_gid)
 
             features.loc[index, 'end_row'] = row
             features.loc[index, 'end_col'] = col
             features.loc[index, 'poi_gid'] = poi_gid
-            features.loc[index, 'region'] = region
 
             try:
                 result = self.least_cost_path(feat_idx, save_path=save_paths)
@@ -1407,14 +1270,12 @@ class TransCapCosts(TieLineCosts):
                                      * features['length_mult'])
 
         # Transformer costs
-        features['xformer_cost_per_mw'] = self._calc_xformer_cost(features)
-        capacity = int(self.capacity_class.strip('MW'))
-        features['xformer_cost'] = (features['xformer_cost_per_mw']
-                                    * capacity)
+        features['xformer_cost_per_mw'] = 0
+        features['xformer_cost'] = 0
 
         # Substation costs
-        features['sub_upgrade_cost'] = self._calc_sub_upgrade_cost(features)
-        features['new_sub_cost'] = self._calc_new_sub_cost(features)
+        features['sub_upgrade_cost'] = 0
+        features['new_sub_cost'] = 0
 
         # Sink costs
         mask = features['category'] == SINK_CAT
@@ -1490,11 +1351,10 @@ class TransCapCosts(TieLineCosts):
     @classmethod
     def run(cls, cost_fpath, sc_point, features, capacity_class, cost_layers,
             radius=None, xmission_config=None, cost_multiplier_layer=None,
-            cost_multiplier_scalar=1, iso_regions_layer_name=ISO_H5_LAYER_NAME,
-            min_line_length=MINIMUM_SPUR_DIST_KM, save_paths=False,
-            simplify_geo=None, friction_layers=None, tracked_layers=None,
-            length_mult_kind="linear", cell_size=CELL_SIZE,
-            use_hard_barrier=True):
+            cost_multiplier_scalar=1, min_line_length=MINIMUM_SPUR_DIST_KM,
+            save_paths=False, simplify_geo=None, friction_layers=None,
+            tracked_layers=None, length_mult_kind="linear",
+            cell_size=CELL_SIZE, use_hard_barrier=True):
         """
         Compute Transmission capital cost of connecting SC point to
         transmission features.
@@ -1530,10 +1390,6 @@ class TransCapCosts(TieLineCosts):
             multipliers. By default, ``None``.
         cost_multiplier_scalar : int | float, optional
             Final cost layer multiplier. By default, ``1``.
-        iso_regions_layer_name : str, default=:obj:`ISO_H5_LAYER_NAME`
-            Name of ISO regions layer in `cost_fpath` file. The layer
-            maps pixels to ISO region ID's (1, 2, 3, 4, etc.) .
-            By default, :obj:`ISO_H5_LAYER_NAME`.
         min_line_length : float, optional
             Minimum line length in km, by default 0
         save_paths : bool, optional
@@ -1605,9 +1461,7 @@ class TransCapCosts(TieLineCosts):
             tcc = cls(cost_fpath, sc_point, features, capacity_class,
                       cl, start_indices=start_indices,
                       row_slice=row_slice, col_slice=col_slice,
-                      xmission_config=xmission_config,
-                      iso_regions_layer_name=iso_regions_layer_name,
-                      cell_size=cell_size)
+                      xmission_config=xmission_config, cell_size=cell_size)
 
             features = tcc.compute(min_line_length=min_line_length,
                                    save_paths=save_paths,
@@ -1637,8 +1491,6 @@ class RegionalTransCapCosts(TransCapCosts):
     Additionally, the `trans_gid`, `min_volt` and `max_volt` columns are
     no longer required in the features input.
     """
-    TRANSFORMER_COST_VOLTAGE = 69
-    _CHECK_FOR_INVALID_REGION = False
 
     def _get_trans_line_idx(self, trans_line):
         """Get the cheapest point on each transmission line.
@@ -1675,29 +1527,6 @@ class RegionalTransCapCosts(TransCapCosts):
     def _check_tline_voltage(self, cost, *__, **___):
         """No adjustments. """
         return cost
-
-    def _calc_xformer_cost(self, features):
-        """Compute transformer costs in $/MW
-
-        Parameters
-        ----------
-        features : pd.DataFrame
-            Table of transmission features to compute transformer costs
-            for
-
-        Returns
-        -------
-        xformer_costs : ndarray
-            vector of $/MW transformer costs
-        """
-        cost = self._config.xformer_cost(self.TRANSFORMER_COST_VOLTAGE,
-                                         self.tie_line_voltage)
-        xformer_costs = np.full(len(features), cost)
-
-        mask = features['region'] == self._config['iso_lookup']['TEPPC']
-        xformer_costs[mask] = 0
-
-        return xformer_costs
 
 
 class ReinforcementLineCosts(TieLineCosts):

--- a/tests/test_xmission_least_cost.py
+++ b/tests/test_xmission_least_cost.py
@@ -158,10 +158,10 @@ def _check_baseline_for_gid(gid, p_true, p_test, check_baseline_cols,
         msg = f'values for {c} do not match for sc_point {gid}!'
         # truth set has incorrect mults
         true_mask = ((p_true["dist_km"].astype('float32') >= cutoff)
-                      & (~p_true["category"].isin({TRANS_LINE_CAT})))
+                     & (~p_true["category"].isin({TRANS_LINE_CAT})))
         c_truth = p_true.loc[true_mask, c].values.astype('float32')
         test_mask = ((p_test["dist_km"].astype('float32') >= cutoff)
-                      & (~p_test["category"].isin({TRANS_LINE_CAT})))
+                     & (~p_test["category"].isin({TRANS_LINE_CAT})))
         c_test = p_test.loc[test_mask, c].values.astype('float32')
 
         if c == "trans_cap_cost":

--- a/tests/test_xmission_least_cost.py
+++ b/tests/test_xmission_least_cost.py
@@ -512,7 +512,6 @@ def test_regional_cli_new_layer_names(runner, ri_ba):
 
         with h5py.File(cost_h5_path, "a") as fh:
             tb = fh["transmission_barrier"][:]
-            iso = fh["ISO_regions"][:]
 
             del fh["transmission_barrier"]
             del fh["ISO_regions"]
@@ -520,7 +519,6 @@ def test_regional_cli_new_layer_names(runner, ri_ba):
             assert "ISO_regions" not in fh.keys()
 
             fh.create_dataset("tb", data=tb)
-            fh.create_dataset("iso", data=iso)
 
         config = {
             "log_directory": td,
@@ -538,7 +536,6 @@ def test_regional_cli_new_layer_names(runner, ri_ba):
                                  "multiplier_scalar": 100}],
             "min_line_length": 0,
             "save_paths": False,
-            "iso_regions_layer_name": "iso",
         }
 
         config_path = os.path.join(td, 'config.json')

--- a/tests/test_xmission_least_cost_paths.py
+++ b/tests/test_xmission_least_cost_paths.py
@@ -868,7 +868,7 @@ def test_apply_mults_by_route(runner, route_table):
 
         polarity_config_path = os.path.join(td, 'config_polarity.json')
         polarity_config = {"138": {"ac": 4, "dc": 4.5},
-                            "69": {"ac": 5, "dc": 5.5},
+                           "69": {"ac": 5, "dc": 5.5},
                            "345": {"ac": 6, "dc": 6.5},
                            "500": {"ac": 7, "dc": 7.5}}
         with open(polarity_config_path, 'w') as f:


### PR DESCRIPTION
Deprecate the ISO layer input and the capacity class input, since the new cost surface no longer requires either.