### PR TITLE
Drop unused dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers=[
 ]
 dependencies = [
   "addfips>=0.4.2,<0.5",
-  "dask>=2024.8.0,<2025",
   "fiona>=1.10.1,<2",
   "geopandas>=1.0.1,<2",
   "NREL-gaps>=0.8.0,<0.9",

--- a/reVX/version.py
+++ b/reVX/version.py
@@ -3,4 +3,4 @@
 reVX version number
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Dask dependency was likely left over from older code. Drop for now so that install is easier.