### PR TITLE
Setbacks refresh

### DIFF
--- a/reVX/exclusions/base.py
+++ b/reVX/exclusions/base.py
@@ -225,7 +225,7 @@ class AbstractBaseExclusionsMerger(AbstractExclusionCalculatorInterface):
 
         if 'FIPS' not in regulations_df:
             msg = ('Regulations does not have county FIPS! Please add a '
-                   '"FIPS" columns with the unique county FIPS values.')
+                   "'FIPS' columns with the unique county FIPS values.")
             logger.error(msg)
             raise RuntimeError(msg)
 

--- a/reVX/exclusions/blade_clearance/README.md
+++ b/reVX/exclusions/blade_clearance/README.md
@@ -1,9 +1,10 @@
 # reVX Blade Clearance
 
-The ``reVX`` blade clearance module computes local-only exclusion masks for wind
-siting workflows where jurisdictions define a minimum allowed blade clearance.
+The ``reVX`` blade clearance module computes exclusion masks for wind
+siting workflows where jurisdictions define a minimum allowed blade clearance,
+or where you want to apply a generic minimum clearance requirement everywhere.
 
-It excludes counties where turbine blade clearance is smaller than the local
+It excludes regions where turbine blade clearance is smaller than the relevant
 minimum requirement.
 
 This guide is supplemental to the generated CLI/API docs and follows the same
@@ -17,8 +18,10 @@ Before running blade clearance, make sure you have:
 
 1. A template exclusions HDF5 file (``excl_fpath``) that defines the output
    grid.
-2. A local regulations file (``regulations_fpath``) in ``.csv`` or ``.gpkg``
-   format containing blade-clearance rows.
+2. At least one regulation source:
+  - a local regulations file (``regulations_fpath``) in ``.csv`` or ``.gpkg``
+    format containing blade-clearance rows
+  - a generic minimum clearance requirement
 3. Turbine specifications:
    - ``hub_height`` (m)
    - ``rotor_diameter`` (m)
@@ -44,7 +47,7 @@ required keys below:
     "log_directory": "./logs",
     "log_level": "INFO",
     "excl_fpath": "/path/to/exclusions.h5",
-    "regulations_fpath": "/path/to/blade_clearance_regulations.csv",
+    "generic_minimum_clearance": 85,
     "hub_height": 116,
     "rotor_diameter": 163,
     "replace": false,
@@ -53,7 +56,8 @@ required keys below:
 ```
 
 #### Key input notes
-- Blade clearance mode is local-only. ``regulations_fpath`` is required.
+- Provide at least one of ``regulations_fpath`` or
+  ``generic_minimum_clearance``.
 - You must provide both ``hub_height`` and ``rotor_diameter``.
 - Blade clearance is computed as:
   ``hub_height - rotor_diameter / 2``
@@ -103,8 +107,13 @@ Output values are exclusion-style mask values:
 
 Exclusion behavior is strict:
 
-- a county is excluded when ``blade_clearance < local_minimum``
-- if ``blade_clearance == local_minimum``, the county is not excluded
+- Generic-only: exclude everywhere when
+  ``blade_clearance < generic_minimum_clearance``
+- Local-only: exclude a jurisdiction when
+  ``blade_clearance < local_minimum``
+- Generic + local: start from the generic result, then replace it inside
+  local jurisdictions using the local minimum blade-clearance rule
+- if ``blade_clearance == minimum_requirement``, the region is not excluded
 
 <br>
 
@@ -142,9 +151,9 @@ $ exclusions status -i node_file_path
 <br>
 
 ## Common troubleshooting
-- **Missing local regulations**
-  - Provide a valid ``regulations_fpath``; this mode does not support
-    generic-only operation.
+- **Missing regulations**
+  - Provide a valid ``regulations_fpath``, ``generic_minimum_clearance``,
+    or both.
 - **Partial turbine inputs**
   - Provide both ``hub_height`` and ``rotor_diameter``.
 - **No local regulations applied**

--- a/reVX/exclusions/blade_clearance/_cli.py
+++ b/reVX/exclusions/blade_clearance/_cli.py
@@ -17,18 +17,18 @@ from reVX import __version__
 logger = logging.getLogger(__name__)
 
 
-def compute_blade_clearance_exclusions(excl_fpath, out_dir, regulations_fpath,
-                                       hub_height, rotor_diameter,
+def compute_blade_clearance_exclusions(excl_fpath, out_dir,
+                                       regulations_fpath=None, hub_height=None,
+                                       rotor_diameter=None,
+                                       generic_minimum_clearance=None,
                                        replace=False, hsds=False,
                                        out_layers=None, max_workers=None):
-    """Exclude regions where system blade clearance does not meet requirements
+    """Exclude regions where system blade clearance does not meet requirements.
 
-    Blade clearance restrictions are only computed locally - you must
-    provide a set of local regulations that dictates the minimum blade
-    clearance requirements for each county. The local regulations are
-    then compared to the blade clearance of the system being considered,
-    and any regions where the system does not meet the local blade
-    clearance requirements are excluded.
+    Blade clearance restrictions can be computed from a generic minimum
+    blade clearance requirement, from local regulations, or from both.
+    When both are supplied, local regulations override the generic
+    result inside their jurisdictions.
 
     Parameters
     ----------
@@ -72,6 +72,10 @@ def compute_blade_clearance_exclusions(excl_fpath, out_dir, regulations_fpath,
     rotor_diameter : float | int
         Turbine rotor diameter (m), used along with hub height to
         compute blade clearance.
+    generic_minimum_clearance : float | int, optional
+        Generic minimum blade clearance requirement in meters to apply
+        everywhere outside jurisdictions with local regulations. By
+        default, ``None``.
     replace : bool, optional
         Flag to replace the output GeoTIFF if it already exists.
         By default, ``False``.
@@ -100,17 +104,20 @@ def compute_blade_clearance_exclusions(excl_fpath, out_dir, regulations_fpath,
     logger.debug('Blade clearance exclusions to be computed with:\n'
                  '- hub_height = {}\n'
                  '- rotor_diameter = {}\n'
+                 '- generic_minimum_clearance = {}\n'
                  '- regulations_fpath = {}\n'
                  '- using max_workers = {}\n'
                  '- replace layer if needed = {}\n'
                  '- out_layers = {}\n'
-                 .format(hub_height, rotor_diameter, regulations_fpath,
+                 .format(hub_height, rotor_diameter,
+                         generic_minimum_clearance, regulations_fpath,
                          max_workers, replace, out_layers))
 
     regulations = validate_blade_clearance_regulations_input(
         hub_height=hub_height,
         rotor_diameter=rotor_diameter,
         regulations_fpath=regulations_fpath,
+        generic_minimum_clearance=generic_minimum_clearance,
     )
 
     fn = ("blade_clearance_restrictions_{}hh_{}rd.tif"

--- a/reVX/exclusions/blade_clearance/blade_clearance.py
+++ b/reVX/exclusions/blade_clearance/blade_clearance.py
@@ -21,9 +21,10 @@ class BladeClearanceExclusions(AbstractBaseExclusionsMerger):
     @property
     def description(self):
         """str: Description to be added to excl H5."""
-        return ('Pixels with value 1 are excluded where local minimum blade '
-                'clearance requirements are larger than the turbine\'s blade '
-                'clearance ({} m).'.format(self._regulations.blade_clearance))
+        return ('Pixels with value 1 are excluded where generic or local '
+                'minimum blade clearance requirements are larger than the '
+                'turbine\'s blade clearance ({} m).'
+                .format(self._regulations.blade_clearance))
 
     @property
     def no_exclusions_array(self):
@@ -82,5 +83,12 @@ class BladeClearanceExclusions(AbstractBaseExclusionsMerger):
         )
 
     def compute_generic_exclusions(self, *__, **___):
-        """Return no exclusions because this mode is local-only"""
-        return self.no_exclusions_array
+        """Compute generic blade-clearance exclusions."""
+        generic_limit_exists = self._regulations.generic is not None
+        system_meets_generic_limit = (self._regulations.blade_clearance
+                                      >= self._regulations.generic)
+
+        if not generic_limit_exists or system_meets_generic_limit:
+            return self.no_exclusions_array
+
+        return np.ones_like(self.no_exclusions_array)

--- a/reVX/exclusions/blade_clearance/regulations.py
+++ b/reVX/exclusions/blade_clearance/regulations.py
@@ -12,10 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class BladeClearanceRegulations(AbstractBaseRegulations):
-    """Local-only regulations for minimum blade clearance restrictions"""
+    """Regulations for minimum blade clearance restrictions."""
 
-    def __init__(self, hub_height, rotor_diameter, regulations_fpath):
-        """Initialize local-only blade clearance regulations
+    def __init__(self, hub_height, rotor_diameter, regulations_fpath=None,
+                 generic_minimum_clearance=None):
+        """Initialize blade clearance regulations.
 
         Parameters
         ----------
@@ -25,23 +26,17 @@ class BladeClearanceRegulations(AbstractBaseRegulations):
         rotor_diameter : float | int
             Turbine rotor diameter (m), used along with hub height to
             compute blade clearance.
-        regulations_fpath : str
-            Path to local regulations file.
+        regulations_fpath : str, optional
+            Path to local regulations file. By default, ``None``.
+        generic_minimum_clearance : float | int, optional
+            Generic minimum blade clearance requirement in meters to
+            apply everywhere outside jurisdictions with local
+            regulations. By default, ``None``.
         """
         self._hub_height = float(hub_height)
         self._rotor_diameter = float(rotor_diameter)
-        super().__init__(generic_regulation_value=None,
+        super().__init__(generic_regulation_value=generic_minimum_clearance,
                          regulations_fpath=regulations_fpath)
-
-    def _preflight_check(self, regulations_fpath):
-        """Ensure only local regulations are used for this mode."""
-        if regulations_fpath is None:
-            msg = ('Blade clearance exclusions are local-only and '
-                   'require `regulations_fpath`.')
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        super()._preflight_check(regulations_fpath)
 
     @property
     def tip_height(self):
@@ -76,7 +71,8 @@ class BladeClearanceRegulations(AbstractBaseRegulations):
 
 def validate_blade_clearance_regulations_input(hub_height=None,
                                                rotor_diameter=None,
-                                               regulations_fpath=None):
+                                               regulations_fpath=None,
+                                               generic_minimum_clearance=None):
     """Validate the blade clearance initialization input
 
     Parameters
@@ -88,9 +84,10 @@ def validate_blade_clearance_regulations_input(hub_height=None,
         Turbine rotor diameter (m), used along with hub height to
         compute blade clearance. By default, ``None``.
     regulations_fpath : str, optional
-        Path to local regulations file. This is required for blade
-        clearance exclusions since they are local-only.
-        By default, ``None``.
+        Path to local regulations file. By default, ``None``.
+    generic_minimum_clearance : float | int, optional
+        Generic minimum blade clearance requirement in meters. By
+        default, ``None``.
 
     Returns
     -------
@@ -115,12 +112,9 @@ def validate_blade_clearance_regulations_input(hub_height=None,
                            '`rotor_diameter` when using turbine '
                            'specifications for blade clearance restrictions.')
 
-    if regulations_fpath is None:
-        raise RuntimeError('Blade clearance exclusions are local-only '
-                           'and require `regulations_fpath`.')
-
     return BladeClearanceRegulations(
         hub_height=hub_height,
         rotor_diameter=rotor_diameter,
         regulations_fpath=regulations_fpath,
+        generic_minimum_clearance=generic_minimum_clearance,
     )

--- a/reVX/exclusions/max_height/README.md
+++ b/reVX/exclusions/max_height/README.md
@@ -1,11 +1,11 @@
-# Height Restriction Exclusions (local-only)
+# Height Restriction Exclusions
 
-``reVX`` supports a jurisdiction-only ``height_restriction`` mode that
-excludes entire jurisdictions if your system height exceeds the
-region's allowed maximum height.
+``reVX`` supports a ``height_restriction`` mode that excludes regions
+when your system height exceeds the allowed maximum height.
 
 Use this mode when your regulations data encodes maximum allowed system
-height per jurisdiction (i.e. per geometry).
+height per jurisdiction, or when you want to apply a generic maximum
+allowed height everywhere.
 
 ## Required regulations format
 For rows that should drive this calculation:
@@ -19,17 +19,24 @@ You must provide **exactly one** of the following:
 * Both ``hub_height`` and ``rotor_diameter`` (tip-height computed as ``hub_height + rotor_diameter / 2``)
 
 Unlike normal setbacks, this mode is **local-only**, meaning the
-``regulations_fpath`` input is required
+You must also provide at least one regulation source:
+* ``generic_height_limit`` for a generic maximum allowed system height
+* ``regulations_fpath`` for local jurisdiction-specific limits
+* Or both, in which case local jurisdictions override the generic
+    behavior within their boundaries
 
 ## Minimal config example
 ```json
 {
     "log_level": "INFO",
     "excl_fpath": "/path/to/Exclusions.h5",
-    "regulations_fpath": "./height_regulations.csv",
+    "generic_height_limit": 180,
     "system_height": 210,
 }
 ```
 
-Behavior is strict: a region is excluded only when
-``system_height > local_max_height``.
+Behavior is strict:
+* Generic-only: exclude everywhere when ``system_height > generic_height_limit``
+* Local-only: exclude a jurisdiction only when ``system_height > local_max_height``
+* Generic + local: start from the generic result, then replace it inside
+    local jurisdictions using the local maximum height rule

--- a/reVX/exclusions/max_height/_cli.py
+++ b/reVX/exclusions/max_height/_cli.py
@@ -16,17 +16,20 @@ from reVX import __version__
 logger = logging.getLogger(__name__)
 
 
-def compute_height_exclusions(excl_fpath, out_dir, regulations_fpath,
-                              system_height=None, hub_height=None, rotor_diameter=None, replace=False,
-                              hsds=False, out_layers=None, max_workers=None):
-    """Exclude regions where system height exceeds local limits
+def compute_height_exclusions(excl_fpath, out_dir, regulations_fpath=None,
+                              system_height=None, hub_height=None,
+                              rotor_diameter=None, generic_height_limit=None,
+                              replace=False, hsds=False, out_layers=None,
+                              max_workers=None):
+    """Exclude regions where system height exceeds height limits.
 
     Exclusions can be computed for a specific turbine (hub height and
     rotor diameter) or more generally using a system height.
 
-    Height restrictions are only computed locally - you must provide a
-    set of local regulations that dictates where a system of a given
-    height is allowed.
+    Height restrictions can be computed from a generic maximum allowed
+    system height, from local regulations, or from both. When both are
+    supplied, local regulations override the generic result inside
+    their jurisdictions.
 
     Parameters
     ----------
@@ -75,6 +78,10 @@ def compute_height_exclusions(excl_fpath, out_dir, regulations_fpath,
         Turbine rotor diameter (m), used along with hub height to
         compute blade tip-height which is used as the system height.
         By default, ``None``.
+    generic_height_limit : float | int, optional
+        Generic maximum allowed system height in meters to apply
+        everywhere outside jurisdictions with local regulations. By
+        default, ``None``.
     replace : bool, optional
         Flag to replace the output GeoTIFF if it already exists.
         By default, ``False``.
@@ -104,12 +111,14 @@ def compute_height_exclusions(excl_fpath, out_dir, regulations_fpath,
                  '- system_height = {}\n'
                  '- hub_height = {}\n'
                  '- rotor_diameter = {}\n'
+                 '- generic_height_limit = {}\n'
                  '- regulations_fpath = {}\n'
                  '- using max_workers = {}\n'
                  '- replace layer if needed = {}\n'
                  '- out_layers = {}\n'
                  .format(system_height, hub_height, rotor_diameter,
-                         regulations_fpath, max_workers, replace,
+                     generic_height_limit, regulations_fpath,
+                     max_workers, replace,
                          out_layers))
 
     regulations = validate_height_regulations_input(
@@ -117,6 +126,7 @@ def compute_height_exclusions(excl_fpath, out_dir, regulations_fpath,
         hub_height=hub_height,
         rotor_diameter=rotor_diameter,
         regulations_fpath=regulations_fpath,
+        generic_height_limit=generic_height_limit,
     )
 
     fn = "height_restrictions_{}m.tif".format(int(regulations.system_height))

--- a/reVX/exclusions/max_height/max_height.py
+++ b/reVX/exclusions/max_height/max_height.py
@@ -16,15 +16,15 @@ logger = logging.getLogger(__name__)
 
 
 class HeightRestrictionExclusions(AbstractBaseExclusionsMerger):
-    """Exclude whole regions where system height exceeds local limits."""
+    """Exclude regions where system height exceeds height limits."""
 
     FEATURE_TYPES = {'maximum height', 'maximum turbine height'}
 
     @property
     def description(self):
         """str: Description to be added to excl H5."""
-        return ('Pixels with value 1 are excluded where local maximum '
-                'height regulations are lower than the input system '
+        return ('Pixels with value 1 are excluded where generic or local '
+                'maximum height regulations are lower than the input system '
                 'height ({} m).'.format(self._regulations.system_height))
 
     @property
@@ -84,5 +84,12 @@ class HeightRestrictionExclusions(AbstractBaseExclusionsMerger):
         )
 
     def compute_generic_exclusions(self, *__, **___):
-        """Return no exclusions because this mode is local-only"""
-        return self.no_exclusions_array
+        """Compute generic height-restriction exclusions."""
+        generic_limit_exists = self._regulations.generic is not None
+        system_passes_generic_limit = (self._regulations.system_height
+                                       <= self._regulations.generic)
+
+        if not generic_limit_exists or system_passes_generic_limit:
+            return self.no_exclusions_array
+
+        return np.ones_like(self.no_exclusions_array)

--- a/reVX/exclusions/max_height/regulations.py
+++ b/reVX/exclusions/max_height/regulations.py
@@ -12,31 +12,26 @@ logger = logging.getLogger(__name__)
 
 
 class HeightRestrictionRegulations(AbstractBaseRegulations):
-    """Local-only regulations for maximum system height restrictions"""
+    """Regulations for maximum system height restrictions."""
 
-    def __init__(self, system_height, regulations_fpath):
-        """Initialize local-only height-restriction regulations.
+    def __init__(self, system_height, regulations_fpath=None,
+                 generic_height_limit=None):
+        """Initialize height-restriction regulations.
 
         Parameters
         ----------
         system_height : float | int
             System height in meters.
-        regulations_fpath : str
-            Path to local regulations file.
+        regulations_fpath : str, optional
+            Path to local regulations file. By default, ``None``.
+        generic_height_limit : float | int, optional
+            Generic maximum allowed system height to apply everywhere
+            outside jurisdictions with local regulations. By default,
+            ``None``.
         """
         self._system_height = float(system_height)
-        super().__init__(generic_regulation_value=None,
+        super().__init__(generic_regulation_value=generic_height_limit,
                          regulations_fpath=regulations_fpath)
-
-    def _preflight_check(self, regulations_fpath):
-        """Ensure only local regulations are used for this mode."""
-        if regulations_fpath is None:
-            msg = ('Height restriction exclusions are local-only and '
-                   'require `regulations_fpath`.')
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        super()._preflight_check(regulations_fpath)
 
     @property
     def system_height(self):
@@ -58,9 +53,10 @@ class HeightRestrictionRegulations(AbstractBaseRegulations):
         return float(county_regulations["Value"])
 
 
-def validate_height_regulations_input(system_height=None,
-                                      hub_height=None, rotor_diameter=None,
-                                      regulations_fpath=None):
+def validate_height_regulations_input(system_height=None, hub_height=None,
+                                      rotor_diameter=None,
+                                      regulations_fpath=None,
+                                      generic_height_limit=None):
     """Validate the height regulations initialization input
 
     Specifically, this function raises an error unless exactly one of
@@ -82,6 +78,12 @@ def validate_height_regulations_input(system_height=None,
     rotor_diameter : float | int
         Turbine rotor diameter (m), used along with hub height to
         compute blade tip-height which is used as the system height.
+        By default, ``None``.
+    regulations_fpath : str, optional
+        Path to local regulations file. By default, ``None``.
+    generic_height_limit : float | int, optional
+        Generic maximum allowed system height in meters to apply
+        everywhere outside jurisdictions with local regulations.
         By default, ``None``.
 
     Returns
@@ -113,14 +115,11 @@ def validate_height_regulations_input(system_height=None,
                            'or (`hub_height` and `rotor_diameter`) for '
                            'height restriction exclusions.')
 
-    if regulations_fpath is None:
-        raise RuntimeError('Height restriction exclusions are local-only '
-                           'and require `regulations_fpath`.')
-
     if system_height is None:
         system_height = hub_height + rotor_diameter / 2
 
     return HeightRestrictionRegulations(
         system_height=system_height,
         regulations_fpath=regulations_fpath,
+        generic_height_limit=generic_height_limit,
     )

--- a/reVX/exclusions/regulations.py
+++ b/reVX/exclusions/regulations.py
@@ -113,7 +113,7 @@ class AbstractBaseRegulations(ABC):
         """list: Required columns for regulations DataFrame. """
         cols = self._BASE_REQUIRED_COLUMNS.copy()
         if not self.geometry_provided:
-            cols.append("FIPS")
+            cols.append('FIPS')
 
         return cols
 

--- a/reVX/exclusions/setbacks/README.md
+++ b/reVX/exclusions/setbacks/README.md
@@ -102,7 +102,7 @@ The ``features`` inputs points ``reVX`` to the feature data from which setbacks 
 key should always be another dictionary. The keys in the new dictionary are the names of the setbacks you are computing
 (see the keys of [``SETBACK_SPECS``](https://github.com/NREL/reVX/tree/main/reVX/setbacks/setbacks.py) for all possible
 options - you may have to scroll down after clicking the link), and the values should point to the data on disk.
-There are several ways to point to a data file (though all files must be ``GeoPackages``):
+All feature data files **must** be ``GeoPackages``, but there are several ways to point to them:
 * If the features for a particular setback calculation are contained within a single file, just set the value to the path
   to the file (relative paths are allowed)
 * If the features for a particular setback calculation are spread across several files (this is common practice to speed

--- a/reVX/exclusions/setbacks/README.md
+++ b/reVX/exclusions/setbacks/README.md
@@ -75,7 +75,7 @@ The next important parameter is ``excl_fpath``. This key must be a path that poi
 profile information that determines the shape and projection of the output exclusion arrays. If you are providing a
 ``regulations_fpath`` input and this input is not a GeoPackage, then the ``excl_fpath`` must contain a county FIPS
 layer called ``cnty_fips``. This layer is then used to match local regulations in ``regulations_fpath`` to counties
-on the grid (using the ``"FIPS"`` column in ``regulations_fpath``).
+on the grid (using the ``'FIPS'`` column in ``regulations_fpath``).
 
 If you are running setbacks for a particular wind turbine, fill out the ``hub_height`` and ``rotor_diameter`` inputs,
 and **delete the ``base_setback_dist`` input**. ``reVX`` setbacks calculations do not allow ``base_setback_dist`` if the

--- a/reVX/exclusions/setbacks/_cli.py
+++ b/reVX/exclusions/setbacks/_cli.py
@@ -66,10 +66,16 @@ def preprocess_setbacks_config(config, features,
         :attr:`~reVX.exclusions.setbacks.setbacks.SETBACK_SPECS`
         dictionary or the ``feature_specs`` input dictionary specifying
         the feature type to run setbacks for. The value of each key must
-        be a path or a list of paths to calculate that particular
-        setback for. The path(s) can contain unix-style file-pattern
-        matching syntax to point to multiple files. The paths may be
-        specified relative to the config file. For example::
+        be a path or a list of paths containing the feature data to
+        setback from.
+
+        .. IMPORTANT::
+            The feature data must be in GeoPackage format and files must
+            have the ".gpkg" extension.
+
+        The path(s) can contain unix-style file-pattern matching syntax
+        to point to multiple files. The paths may be specified relative
+        to the config file. For example::
 
             features: {
                 "parcel": "../relative/path/to/parcel_colorado.gpkg",

--- a/reVX/exclusions/setbacks/setbacks.py
+++ b/reVX/exclusions/setbacks/setbacks.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def _format_str(in_str):
     """Format a string like regulation class does. """
-    return in_str.strip().lower().replace("-", " ").replace("_", " ")
+    return in_str.strip().casefold().replace("-", " ").replace("_", " ")
 
 
 def _camel_case_str(in_str):
@@ -79,6 +79,7 @@ def setbacks_calculator(feature_type, buffer_type="default",
 
     camel_case_feature = "".join(map(_camel_case_str, sorted(feature_type)))
     feature_type = set(map(_format_str, feature_type))
+    feature_type |= {f"{ft}s" for ft in feature_type}  # pluralize
 
     if buffer_type not in BUFFERS:
         msg = ("Unknown buffer type specified: {!r}. Must be one of {}"
@@ -106,42 +107,42 @@ def setbacks_calculator(feature_type, buffer_type="default",
 
 SETBACK_SPECS = {
     "parcel": {
-        "feature_type": "property line",
+        "feature_type": ["property line", "parcel", "pline"],
         "buffer_type": "parcel",
         "feature_filter_type": "centroid",
         "feature_subtypes_to_exclude": None,
         "num_features_per_worker": 10_000,
     },
     "rail": {
-        "feature_type": "railroads",
+        "feature_type": ["rail", "railroads", "rr"],
         "buffer_type": "default",
         "feature_filter_type": "clip",
         "feature_subtypes_to_exclude": None,
         "num_features_per_worker": 10_000,
     },
     "road": {
-        "feature_type": ['roads', 'highways', 'highways 111'],
+        "feature_type": ['road', 'highway', 'highways 111'],
         "buffer_type": "default",
         "feature_filter_type": "clip",
         "feature_subtypes_to_exclude": None,
         "num_features_per_worker": 10_000,
     },
     "structure": {
-        "feature_type": "structures",
+        "feature_type": ["structure", "building", "struct"],
         "buffer_type": "default",
         "feature_filter_type": "centroid",
         "feature_subtypes_to_exclude": ["Occupied Community Buildings"],
         "num_features_per_worker": 10_000,
     },
     "transmission": {
-        "feature_type": "transmission",
+        "feature_type": ["transmission", "transmission line", "tl"],
         "buffer_type": "default",
         "feature_filter_type": "clip",
         "feature_subtypes_to_exclude": None,
         "num_features_per_worker": 10_000,
     },
     "water": {
-        "feature_type": "water",
+        "feature_type": ["water", "lake", "river", "stream"],
         "buffer_type": "default",
         "feature_filter_type": "clip",
         "feature_subtypes_to_exclude": None,

--- a/reVX/exclusions/turbine_flicker/turbine_flicker.py
+++ b/reVX/exclusions/turbine_flicker/turbine_flicker.py
@@ -204,7 +204,7 @@ class TurbineFlicker(AbstractBaseExclusionsMerger):
         """Map county FIPS values to corresponding SC gids. """
 
         self._fips_to_gid = {}
-        reg_fips = self._regulations.df.FIPS.unique()
+        reg_fips = self._regulations.df['FIPS'].unique()
         with SupplyCurveExtent(self._excl_fpath, resolution=self._res) as sc:
             for gid in self._sc_points.index:
                 for fips in np.unique(sc.get_excl_points('cnty_fips', gid)):

--- a/reVX/handlers/geopackage.py
+++ b/reVX/handlers/geopackage.py
@@ -61,8 +61,8 @@ class GPKGMeta:
         """str: Name of the primary key column in the user data table. """
         with sqlite3.connect(self.filename) as con:
             cursor = con.cursor()
-            cursor.execute("PRAGMA table_info({})"
-                           .format(self.primary_table))
+            table_name = _escape_sqlite_identifier(self.primary_table)
+            cursor.execute("PRAGMA table_info({})".format(table_name))
             pragma = cursor.fetchall()
             pk_name = [info[1] for info in pragma if info[-1]]
             assert len(pk_name) == 1, "Found multiple Primary Key columns"
@@ -125,3 +125,9 @@ class GPKGMeta:
                                    maxx=maxx, minx=minx, maxy=maxy, miny=miny))
             ids = tuple(id_[0] for id_ in cursor.fetchall())
         return ids
+
+
+def _escape_sqlite_identifier(identifier):
+    """Escape a SQLite identifier for use in SQL statements."""
+    return '"{}"'.format(identifier.replace('"', '""'))
+

--- a/tests/test_exclusions_blade_clearance.py
+++ b/tests/test_exclusions_blade_clearance.py
@@ -96,6 +96,19 @@ def test_validate_blade_clearance_regulations_input():
             rotor_diameter=100,
         )
 
+    with tempfile.TemporaryDirectory() as td:
+        regs_fpath = os.path.join(td, 'blade_regs.csv')
+        _make_blade_clearance_regs(regs_fpath, {44007}, {44009})
+
+        regs = validate_blade_clearance_regulations_input(
+            hub_height=120,
+            rotor_diameter=100,
+            regulations_fpath=regs_fpath,
+            generic_minimum_clearance=85,
+        )
+        assert isinstance(regs, BladeClearanceRegulations)
+        assert np.isclose(regs.generic, 85)
+
 
 def test_blade_clearance_regulations_conversion():
     """Test blade-clearance, tip-height, and value conversions."""
@@ -130,6 +143,36 @@ def test_blade_clearance_regulations_conversion():
 
         with pytest.warns(UserWarning, match='Cannot create blade clearance'):
             assert bc._county_regulation_value(county_regs.loc[44007]) is None
+
+
+def test_select_blade_clearance_regulations_generic_only():
+    """Test selecting generic-only blade clearance regulations."""
+    regs = BladeClearanceRegulations(
+        hub_height=120,
+        rotor_diameter=80,
+        generic_minimum_clearance=85,
+    )
+    assert isinstance(regs, BladeClearanceRegulations)
+    assert np.isclose(regs.blade_clearance, 80)
+    assert np.isclose(regs.generic, 85)
+
+
+@pytest.mark.parametrize(
+    ('generic_minimum_clearance', 'expected_value'),
+    [(70, 0), (80, 0), (90, 1)],
+)
+def test_generic_blade_clearance_exclusions(generic_minimum_clearance,
+                                            expected_value):
+    """Test generic-only exclusions for blade clearance restrictions."""
+    regs = BladeClearanceRegulations(
+        hub_height=120,
+        rotor_diameter=80,
+        generic_minimum_clearance=generic_minimum_clearance,
+    )
+    bc = BladeClearanceExclusions(EXCL_H5, regs, features=None)
+    out = bc.compute_exclusions(max_workers=1)
+
+    assert np.all(out == expected_value)
 
 
 @pytest.mark.parametrize('max_workers', [1, 4])
@@ -215,6 +258,53 @@ def test_blade_clearance_exclusions_feature_filtering():
         assert np.allclose(out, truth)
 
 
+def test_merged_blade_clearance_exclusions():
+    """Test local regulations override the generic blade-clearance exclusion."""
+    with ExclusionLayers(EXCL_H5) as exc:
+        fips = exc['cnty_fips']
+        all_fips = sorted(set(np.unique(fips[fips > 0])))
+
+    restricted = {all_fips[0], all_fips[3]}
+    unrestricted = {all_fips[1], all_fips[10]}
+    with tempfile.TemporaryDirectory() as td:
+        regs_fpath = os.path.join(td, 'blade_regs.csv')
+        _make_blade_clearance_regs(regs_fpath, restricted, unrestricted,
+                                   restricted_value=90,
+                                   unrestricted_value=70)
+
+        generic_regs = BladeClearanceRegulations(hub_height=120,
+                                                 rotor_diameter=80,
+                                                 generic_minimum_clearance=90)
+        generic = BladeClearanceExclusions(EXCL_H5, generic_regs,
+                                           features=None)
+        generic_layer = generic.compute_exclusions(max_workers=1)
+
+        local_regs = BladeClearanceRegulations(regulations_fpath=regs_fpath,
+                                               hub_height=120,
+                                               rotor_diameter=80)
+        local = BladeClearanceExclusions(EXCL_H5, local_regs,
+                                         features=None)
+        local_layer = local.compute_exclusions(max_workers=1)
+
+        merged_regs = BladeClearanceRegulations(regulations_fpath=regs_fpath,
+                                                hub_height=120,
+                                                rotor_diameter=80,
+                                                generic_minimum_clearance=90)
+        merged = BladeClearanceExclusions(EXCL_H5, merged_regs,
+                                          features=None)
+        merged_layer = merged.compute_exclusions(max_workers=1)
+
+        local.pre_process_regulations()
+        local_fips = set(local.regulations_table['FIPS'])
+        local_mask = np.isin(fips, list(local_fips))
+
+        assert np.all(generic_layer == 1)
+        assert np.allclose(local_layer, np.isin(fips, list(restricted)))
+        assert np.allclose(merged_layer[local_mask], local_layer[local_mask])
+        assert np.allclose(merged_layer[~local_mask],
+                           generic_layer[~local_mask])
+
+
 def test_cli_blade_clearance(runner):
     """Test CLI for local-only blade clearance mode."""
     with ExclusionLayers(EXCL_H5) as exc:
@@ -254,6 +344,35 @@ def test_cli_blade_clearance(runner):
 
         truth = np.isin(fips, list(restricted)).astype(np.uint8)
         assert np.allclose(out, truth)
+
+    LOGGERS.clear()
+
+
+def test_cli_generic_blade_clearance(runner):
+    """Test CLI for generic-only blade clearance mode."""
+    with tempfile.TemporaryDirectory() as td:
+        config = {
+            "log_directory": td,
+            "execution_control": {"option": "local"},
+            "excl_fpath": EXCL_H5,
+            "generic_minimum_clearance": 90,
+            "log_level": "INFO",
+            "replace": True,
+            "hub_height": 120,
+            "rotor_diameter": 80,
+        }
+        config_path = os.path.join(td, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+
+        result = runner.invoke(cli, ['blade-clearance', '-c', config_path])
+        assert result.exit_code == 0, result.output
+
+        test_fp = _find_out_tiff_file(td)
+        with Geotiff(test_fp) as tif:
+            out = tif.values
+
+        assert np.all(out == 1)
 
     LOGGERS.clear()
 

--- a/tests/test_exclusions_max_height.py
+++ b/tests/test_exclusions_max_height.py
@@ -186,29 +186,23 @@ def test_merged_height_restriction_exclusions():
                                       restricted_height=120,
                                       unrestricted_height=180)
 
-        generic_regs = HeightRestrictionRegulations(
-            system_height=150,
-            generic_height_limit=120,
-        )
+        generic_regs = HeightRestrictionRegulations(system_height=150,
+                                                    generic_height_limit=120)
         generic = HeightRestrictionExclusions(EXCL_H5, generic_regs,
                                              features=None)
         generic_layer = generic.compute_exclusions(max_workers=1)
 
-        local_regs = HeightRestrictionRegulations(
-            regulations_fpath=regs_fpath,
-            system_height=150,
-        )
+        local_regs = HeightRestrictionRegulations(regulations_fpath=regs_fpath,
+                                                  system_height=150)
         local = HeightRestrictionExclusions(EXCL_H5, local_regs,
                                            features=None)
         local_layer = local.compute_exclusions(max_workers=1)
 
         merged_regs = HeightRestrictionRegulations(
-            regulations_fpath=regs_fpath,
-            system_height=150,
-            generic_height_limit=120,
-        )
+            regulations_fpath=regs_fpath, system_height=150,
+            generic_height_limit=120)
         merged = HeightRestrictionExclusions(EXCL_H5, merged_regs,
-                                            features=None)
+                                             features=None)
         merged_layer = merged.compute_exclusions(max_workers=1)
 
         local.pre_process_regulations()

--- a/tests/test_exclusions_max_height.py
+++ b/tests/test_exclusions_max_height.py
@@ -91,6 +91,14 @@ def test_validate_height_restriction_regulations_input():
             system_height=150,
         )
 
+    regs = validate_height_regulations_input(
+        system_height=150,
+        generic_height_limit=180,
+        regulations_fpath=REGS_FPATH,
+    )
+    assert isinstance(regs, HeightRestrictionRegulations)
+    assert np.isclose(regs.generic, 180)
+
     with pytest.raises(RuntimeError):
         validate_height_regulations_input(
             system_height=150,
@@ -108,6 +116,34 @@ def test_select_height_restriction_regulations():
     )
     assert isinstance(regs, HeightRestrictionRegulations)
     assert np.isclose(regs.system_height, 150)
+
+
+def test_select_height_restriction_regulations_generic_only():
+    """Test selecting generic-only height restriction regulations."""
+    regs = HeightRestrictionRegulations(
+        system_height=150,
+        generic_height_limit=180,
+    )
+    assert isinstance(regs, HeightRestrictionRegulations)
+    assert np.isclose(regs.system_height, 150)
+    assert np.isclose(regs.generic, 180)
+
+
+@pytest.mark.parametrize(
+    ('generic_height_limit', 'expected_value'),
+    [(120, 1), (150, 0), (180, 0)],
+)
+def test_generic_height_restriction_exclusions(generic_height_limit,
+                                               expected_value):
+    """Test generic-only exclusions for height restrictions."""
+    regs = HeightRestrictionRegulations(
+        system_height=150,
+        generic_height_limit=generic_height_limit,
+    )
+    hr = HeightRestrictionExclusions(EXCL_H5, regs, features=None)
+    out = hr.compute_exclusions(max_workers=1)
+
+    assert np.all(out == expected_value)
 
 
 @pytest.mark.parametrize('max_workers', [1, 4])
@@ -134,6 +170,56 @@ def test_height_restriction_exclusions(max_workers):
 
         truth = np.isin(fips, list(restricted)).astype(np.uint8)
         assert np.allclose(out, truth)
+
+
+def test_merged_height_restriction_exclusions():
+    """Test local regulations override the generic height exclusion."""
+    with ExclusionLayers(EXCL_H5) as exc:
+        fips = exc['cnty_fips']
+        all_fips = sorted(set(np.unique(fips[fips > 0])))
+
+    restricted = {all_fips[0], all_fips[3]}
+    unrestricted = {all_fips[1], all_fips[10]}
+    with tempfile.TemporaryDirectory() as td:
+        regs_fpath = os.path.join(td, 'height_regs.csv')
+        _make_height_restriction_regs(regs_fpath, restricted, unrestricted,
+                                      restricted_height=120,
+                                      unrestricted_height=180)
+
+        generic_regs = HeightRestrictionRegulations(
+            system_height=150,
+            generic_height_limit=120,
+        )
+        generic = HeightRestrictionExclusions(EXCL_H5, generic_regs,
+                                             features=None)
+        generic_layer = generic.compute_exclusions(max_workers=1)
+
+        local_regs = HeightRestrictionRegulations(
+            regulations_fpath=regs_fpath,
+            system_height=150,
+        )
+        local = HeightRestrictionExclusions(EXCL_H5, local_regs,
+                                           features=None)
+        local_layer = local.compute_exclusions(max_workers=1)
+
+        merged_regs = HeightRestrictionRegulations(
+            regulations_fpath=regs_fpath,
+            system_height=150,
+            generic_height_limit=120,
+        )
+        merged = HeightRestrictionExclusions(EXCL_H5, merged_regs,
+                                            features=None)
+        merged_layer = merged.compute_exclusions(max_workers=1)
+
+        local.pre_process_regulations()
+        local_fips = set(local.regulations_table['FIPS'])
+        local_mask = np.isin(fips, list(local_fips))
+
+        assert np.all(generic_layer == 1)
+        assert np.allclose(local_layer, np.isin(fips, list(restricted)))
+        assert np.allclose(merged_layer[local_mask], local_layer[local_mask])
+        assert np.allclose(merged_layer[~local_mask],
+                           generic_layer[~local_mask])
 
 
 def test_cli_height_restriction(runner):
@@ -172,6 +258,34 @@ def test_cli_height_restriction(runner):
 
         truth = np.isin(fips, list(restricted)).astype(np.uint8)
         assert np.allclose(out, truth)
+
+    LOGGERS.clear()
+
+
+def test_cli_generic_height_restriction(runner):
+    """Test CLI for generic-only height restriction mode."""
+    with tempfile.TemporaryDirectory() as td:
+        config = {
+            "log_directory": td,
+            "execution_control": {"option": "local"},
+            "excl_fpath": EXCL_H5,
+            "generic_height_limit": 120,
+            "log_level": "INFO",
+            "replace": True,
+            "system_height": 150,
+        }
+        config_path = os.path.join(td, 'config.json')
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+
+        result = runner.invoke(cli, ['max-height', '-c', config_path])
+        assert result.exit_code == 0, result.output
+
+        test_fp = _find_out_tiff_file(td)
+        with Geotiff(test_fp) as tif:
+            out = tif.values
+
+        assert np.all(out == 1)
 
     LOGGERS.clear()
 

--- a/tests/test_exclusions_setbacks.py
+++ b/tests/test_exclusions_setbacks.py
@@ -341,14 +341,14 @@ def test_local_structures(max_workers, county_wind_regulations):
     """
     Test local structures setbacks
     """
-    mask = county_wind_regulations.df["FIPS"] == 44005
+    mask = county_wind_regulations.df['FIPS'] == 44005
     initial_regs_count = county_wind_regulations.df[mask].shape[0]
 
     structures_path = os.path.join(TESTDATADIR, 'setbacks', 'RhodeIsland.gpkg')
     setbacks = SETBACKS["structure"](EXCL_H5, county_wind_regulations,
                                      features=structures_path)
 
-    mask = setbacks.regulations_table["FIPS"] == 44005
+    mask = setbacks.regulations_table['FIPS'] == 44005
     final_regs_count = setbacks.regulations_table[mask].shape[0]
 
     # county 44005 has two non-overlapping geometries

--- a/tests/test_exclusions_setbacks.py
+++ b/tests/test_exclusions_setbacks.py
@@ -365,6 +365,11 @@ def test_local_structures_no_fips(max_workers, county_wind_regulations_gpkg,
 
     structures_path = os.path.join(TESTDATADIR, 'setbacks', 'RhodeIsland.gpkg')
 
+    assert county_wind_regulations_gpkg.geometry_provided
+    assert 'FIPS' in county_wind_regulations_gpkg.df
+    assert county_wind_regulations_gpkg_no_fips.geometry_provided
+    assert 'FIPS' not in county_wind_regulations_gpkg_no_fips.df
+
     baseline = SETBACKS["structure"](EXCL_H5,
                                      county_wind_regulations_gpkg,
                                      features=structures_path)

--- a/tests/test_exclusions_setbacks.py
+++ b/tests/test_exclusions_setbacks.py
@@ -143,7 +143,7 @@ def _assert_matches_railroad_baseline(test, regs):
     with ExclusionLayers(EXCL_H5) as exc:
         fips = exc['cnty_fips']
 
-    inds = np.isin(fips.flatten(), regs.df.FIPS.unique())
+    inds = np.isin(fips.flatten(), regs.df['FIPS'].unique())
     assert np.allclose(test.flatten()[inds], baseline.flatten()[inds])
 
 
@@ -493,7 +493,7 @@ def test_local_parcels_solar(max_workers, regulations_fpath):
         regulations['Feature Type'].str.strip() == 'Property Line'
     )
     counties_should_have_exclusions = set(
-        regulations[property_lines].FIPS.unique()
+        regulations[property_lines]['FIPS'].unique()
     )
     counties_with_exclusions_but_not_in_regulations_csv = (
         counties_with_exclusions - counties_should_have_exclusions
@@ -532,7 +532,7 @@ def test_local_parcels_wind(max_workers, regulations_fpath):
         regulations['Feature Type'].str.strip() == 'Property Line'
     )
     counties_should_have_exclusions = set(
-        regulations[property_lines].FIPS.unique()
+        regulations[property_lines]['FIPS'].unique()
     )
     counties_with_exclusions_but_not_in_regulations_csv = (
         counties_with_exclusions - counties_should_have_exclusions
@@ -594,7 +594,7 @@ def test_local_water_solar(max_workers, regulations_fpath):
     regulations = pd.read_csv(regulations_fpath)
     feats = regulations['Feature Type'].str.strip().str.lower()
     counties_should_have_exclusions = set(
-        regulations[feats == 'water'].FIPS.unique()
+        regulations[feats == 'water']['FIPS'].unique()
     )
     counties_with_exclusions_but_not_in_regulations_csv = (
         counties_with_exclusions - counties_should_have_exclusions
@@ -628,7 +628,7 @@ def test_local_water_wind(max_workers, regulations_fpath):
     regulations = pd.read_csv(regulations_fpath)
     feats = regulations['Feature Type'].str.strip().str.lower()
     counties_should_have_exclusions = set(
-        regulations[feats == 'water'].FIPS.unique()
+        regulations[feats == 'water']['FIPS'].unique()
     )
     counties_with_exclusions_but_not_in_regulations_csv = (
         counties_with_exclusions - counties_should_have_exclusions

--- a/tests/test_handlers_geopackage.py
+++ b/tests/test_handlers_geopackage.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""GeoPackage handler tests."""
+
+from pathlib import Path
+import shutil
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from reVX.handlers.geopackage import GPKGMeta
+
+
+def _write_geopackage(path, layer_name):
+    """Write a single-feature geopackage with a specific layer name."""
+    gdf = gpd.GeoDataFrame(
+        {"value": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326"
+    )
+
+    write_path = path if path.suffix == ".gpkg" else path.with_suffix(".gpkg")
+    gdf.to_file(write_path, layer=layer_name, driver="GPKG", index=False)
+
+    if write_path != path:
+        shutil.move(write_path, path)
+
+
+@pytest.mark.parametrize("filename", ["OR.gpkg", "IN.gpkg", "AND.gpk"])
+def test_primary_key_column_uses_escaped_table_name(tmp_path, filename):
+    """Reserved-word layer names should not break PRAGMA introspection."""
+    gpkg_path = tmp_path / filename
+    layer_name = Path(filename).stem
+    _write_geopackage(gpkg_path, layer_name)
+
+    meta = GPKGMeta(gpkg_path)
+
+    assert meta.primary_table == layer_name
+    assert meta.primary_key_column == "fid"


### PR DESCRIPTION
Huge thanks to @gabezuckerman for stress testing the setbacks code. Based on his findings, this PR updates the following setbacks issues: 

- Fix a bug with `OR.gpkg` style filenames for feature inputs
- Allow more feature types to be used in the regulations input, such as both "rail" and "railroads"
- Ensure FIPS column not required in GeoPackage input
- Allow generic values for both blade clearance and max turbine height